### PR TITLE
v1.8.0 feat: add durable receive and human-gated native sends

### DIFF
--- a/.github/workflows/openkakao-cli-ci.yml
+++ b/.github/workflows/openkakao-cli-ci.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - "src/**"
       - "tests/**"
+      - "native/**"
+      - "build.rs"
       - "Cargo.toml"
       - "Cargo.lock"
       - "rust-toolchain.toml"
@@ -13,6 +15,8 @@ on:
     paths:
       - "src/**"
       - "tests/**"
+      - "native/**"
+      - "build.rs"
       - "Cargo.toml"
       - "Cargo.lock"
       - "rust-toolchain.toml"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,12 @@ openkakao-cli local-schema
 # Preview actions without executing
 openkakao-cli send 123 "message" --dry-run --json
 openkakao-cli delete 123 456 --dry-run --json
+
+# Queue an AX send proposal. This never sends a KakaoTalk message.
+openkakao-cli --no-prefix safe-send propose "chat name" "message" \
+  --reply-chat-id 123 --reply-log-id 456 \
+  --idempotency-key "reply:123:456:policy-v1" --json
+openkakao-cli safe-send list --json
 ```
 
 ### Safe commands (REST API, lower risk)
@@ -41,6 +47,23 @@ openkakao-cli delete <chat_id> <log_id> -y --json
 openkakao-cli edit <chat_id> <log_id> "new" -y --json
 openkakao-cli react <chat_id> <log_id> --json
 ```
+
+`safe-send approve <intent_id>` is the preferred AX write path. It requires
+`allow_ax_send = true`, an exact `allowed_send_chats` match, an interactive
+terminal, the proposal's 12-character approval code, and macOS device-owner
+authentication (Touch ID or login password). Direct real `local-send` uses the
+same OS authentication. Agents stop after `safe-send propose`; a human reviews
+and approves. There is no unattended approval mode. An `uncertain` result is
+inspected in KakaoTalk and never retried automatically.
+
+The AX implementation is native to `openkakao-cli`; Orca and `$computer-use`
+are not runtime dependencies. Do not replace the domain-level workflow with
+generic desktop `click`, `type`, or `press-key` actions. Before commit, the AX
+adapter verifies the KakaoTalk bundle/team code signature, requires one unique
+exact-name chat-list row, an empty composer, and verified row/text read-back
+immediately before Return. After Return may have been pressed, any result
+lacking both a cleared composer and an additional exact-text outgoing bubble is
+`uncertain`.
 
 ## Unattended Mode
 
@@ -66,10 +89,10 @@ min_unattended_send_interval_secs = 10
 
 ## Recommended Agent Workflow
 
-1. **Read** with `local-chats` / `local-read` (zero risk)
-2. **Preview** with `--dry-run` before any write
-3. **Execute** only after user confirmation
-4. **Prefer** `--me` flag for testing sends
+1. **Read** with local read commands or `notif-watch` (zero Kakao write risk)
+2. **Propose** with `safe-send propose`; use the source `chat_id` + `log_id` in the idempotency key
+3. **Stop** and return the intent, exact target, message, and approval code to the human
+4. **Human approval** happens only through interactive `safe-send approve`, its approval code, and macOS device-owner authentication
 
 ## JSON Output
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-09-02
+
+### Changed
+- Hardened `notif-watch` for long-running automation: duplicate rows emit once, events are read in deterministic chronological order, sub-second notification timestamps are preserved, and terminal states are pruned after a 24-hour grace period once Notification Center no longer retains them.
+- AX sends now classify transport completion as `verified`, `not_sent`, or `uncertain`. A failure proven to occur before the final Return key returns the proposal to `proposed`; once commit may have begun, an unverified result remains quarantined as `uncertain` with no automatic retry.
+
+### Added
+- `safe-send propose/list/approve/cancel` adds a crash-safe, local SQLite outbox for AX sends. Proposals are content-bound by a 12-character approval code, expire after 15 minutes, require both an interactive terminal and macOS device-owner authentication with no unattended bypass, enforce conservative global/per-chat budgets, and quarantine ambiguous or interrupted sends as `uncertain` instead of retrying automatically.
+- `notif-watch --replay-existing` processes KakaoTalk messages already retained in Notification Center at startup, covering watcher downtime without changing the default no-flood baseline behavior.
+- `notif-watch --durable` persists notifications to `~/.config/openkakao/receive_inbox.db` before delivery, deduplicates stable room/message identities across restarts, and atomically leases each delivery to one worker. Unacknowledged hook/webhook deliveries retry with capped exponential backoff; rate-limited sinks remain pending, and an event is quarantined after eight failed attempts so it cannot block later events forever.
+- A `launchd` LaunchAgent and wrapper example supervise the durable, login-free notification receiver with `RunAtLoad`, `KeepAlive`, and restart throttling.
+
+### Fixed
+- `notif-watch` now fails immediately with an actionable Full Disk Access/`doctor` hint when its initial Notification Center DB read cannot succeed, while still retrying transient failures after startup. SQLite row errors and incompatible KakaoTalk notification schemas are no longer silently discarded, and `doctor` checks schema compatibility as well as access and registration.
+- Login-free local commands (`notif-watch`, `ax-watch`, `ax-read`, `local-*`, offline cache inspection, and `doctor`) no longer print the unrelated warning about broken server-login flows at startup.
+- `local-send`/`safe-send` authenticate the running KakaoTalk process by its Apple code signature, require macOS device-owner authentication before a real send, verify the selected chat row and composer immediately before Return, and bound every recursive AX snapshot. They refuse ambiguous exact-name targets and mark delivery verified only when the composer clears and an additional exact-text outgoing bubble appears.
+- Webhook delivery no longer follows redirects to unvalidated destinations, command-hook stdin write failures are surfaced, and human-readable event output escapes terminal and bidirectional control characters.
+
 ## [1.7.1] - 2026-07-23
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ OpenKakao에 기여해주셔서 감사합니다.
 
 ```bash
 git clone https://github.com/JungHoonGhae/openkakao-cli.git
-cd openkakao/openkakao-cli
+cd openkakao-cli
 cargo build
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1479,6 +1479,7 @@ dependencies = [
  "base64",
  "bson",
  "byteorder",
+ "cc",
  "chrono",
  "clap",
  "clap_complete",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,7 +1469,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openkakao-cli"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "accessibility",
  "accessibility-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,6 @@ core-graphics = { version = "0.25", features = ["elcapitan"] }
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
+
+[build-dependencies]
+cc = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openkakao-cli"
-version = "1.7.1"
+version = "1.8.0"
 edition = "2021"
 description = "KakaoTalk CLI for macOS — send/read messages without server login via Accessibility automation"
 license = "MIT"

--- a/README.en.md
+++ b/README.en.md
@@ -26,7 +26,7 @@
 > **Works fully without logging in.** `local-send`/`ax-read` drive the real KakaoTalk UI directly via the macOS Accessibility API — no server session needed for either sending real messages or reading recent chat history. Just KakaoTalk running and already logged in — see [Quick Start](#quick-start) below.
 
 > [!NOTE]
-> Server login (`login --save`/`login --manual`) is broken on most recent KakaoTalk macOS builds ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15), [#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)). **Do NOT repeatedly retry login from an unregistered device** — Kakao may block your account's "sub-device login" or restrict the account (this has actually been reported). The local SQLCipher DB path (`local-chats`/`local-read`/`local-search`) is also currently unreliable on recent builds — use `ax-read` instead.
+> Server login (`login --save`/`login --manual`) is broken on most recent KakaoTalk macOS builds ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15), [#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)). **Do NOT repeatedly retry login from an unregistered device** — Kakao may block your account's "sub-device login" or restrict the account (this has actually been reported). The local SQLCipher DB path (`local-chats`/`local-read`/`local-search`) is also currently unreliable on recent builds — use `ax-read` for reads, and `notif-watch` (notification stream, window-independent, self-sends excluded) or `ax-watch` for receive detection.
 
 > [!WARNING]
 > This project is an unofficial CLI and is not affiliated with or endorsed by Kakao Corp. It is built for research, automation, and local workflows around the macOS KakaoTalk app.
@@ -85,10 +85,19 @@ openkakao-cli local-send "chat display name" "Hello from CLI!" -y         # actu
 # 3. Read recent messages — same AX approach, scrapes what's rendered on screen
 openkakao-cli ax-read "chat display name" -n 20
 
-# 4. Detect incoming messages — polls the chat list and fires a hook/webhook
+# 4. Detect incoming messages (AX) — polls the chat list and fires a hook/webhook
 #    when a chat's unread count rises (no server contact)
 openkakao-cli ax-watch --hook-cmd 'my-script.sh'
+
+# 5. Detect incoming messages (notification stream) — polls the macOS Notification
+#    Center DB for new messages. Works with the KakaoTalk window closed, and your
+#    own sent messages are excluded (no login, no server contact)
+openkakao-cli notif-watch --json
+openkakao-cli notif-watch --hook-keyword 'urgent' --hook-cmd 'my-script.sh'
 ```
+
+> [!TIP]
+> **`ax-watch` vs `notif-watch`** — both detect incoming messages without login. `notif-watch` reads the macOS Notification Center DB (a plaintext SQLite), so it **works even when the KakaoTalk window is closed, minimized, or on another Space**, and since notifications only fire for received messages it **excludes your own sends automatically**. The trade-off: **muted / notifications-off chats** and the **chat you're currently focused on** post no notification, so they aren't seen, and it's a forward-only live stream (not history). Run `ax-watch` alongside it if you need those chats with the window open. Events are NDJSON with `event_type`, `chat_name`, `chat_id` (room id), `log_id` (message id), `message`, `attachment`, `received_at`.
 
 ### Server-login path (mostly broken right now)
 
@@ -195,6 +204,7 @@ Read-only operations are always available:
 |---------|-------------|----------------|
 | `ax-read <chat_name>` | Scrape recent messages from an open chat window (AX) | None |
 | `ax-watch` | Poll the chat list, fire a hook/webhook when unread count rises (AX, no login) | None |
+| `notif-watch` | Poll the macOS Notification Center DB for new incoming messages — window-independent, self-sends excluded (no login) | None |
 | `local-chats` | List chats from local DB (unreliable on current builds) | None |
 | `local-read <id>` | Read messages from local DB (unreliable on current builds) | None |
 | `local-search "keyword"` | Search local DB (unreliable on current builds) | None |
@@ -205,6 +215,8 @@ Read-only operations are always available:
 
 > [!NOTE]
 > `local-send`/`ax-read`/`ax-watch` need to find KakaoTalk's **main chat-list window** via the macOS Accessibility API. If that window is **minimized**, or on a different **macOS Space** (virtual desktop) than the one you're currently viewing, it won't be found — restoring it automatically isn't possible without risking a stolen foreground focus, so these commands give a clear error and ask you to restore it by hand instead. If this keeps happening, a one-time fix is: right-click the KakaoTalk Dock icon → Options → Assign To → All Desktops.
+>
+> **`notif-watch` is not subject to this** — it reads the macOS Notification Center DB rather than an AX window, so it works regardless of window state (but muted / focused chats post no notification and so aren't seen).
 
 ## Requirements
 

--- a/README.en.md
+++ b/README.en.md
@@ -15,7 +15,7 @@
 <p align="center">
   <a href="https://github.com/JungHoonGhae/openkakao-cli/stargazers"><img src="https://img.shields.io/github/stars/JungHoonGhae/openkakao-cli" alt="GitHub stars" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="MIT License" /></a>
-  <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust" /></a>
+  <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/Rust-1.95-orange.svg" alt="Rust" /></a>
   <a href="https://openkakao.vercel.app/"><img src="https://img.shields.io/badge/status-active-brightgreen" alt="Status Active" /></a>
   <a href="https://openkakao.vercel.app/"><img src="https://img.shields.io/badge/docs-fumadocs-black" alt="Docs" /></a>
 </p>
@@ -255,7 +255,7 @@ Read-only operations are always available:
 | Requirement | Notes |
 |-------------|-------|
 | macOS | KakaoTalk desktop app must be installed and logged in |
-| Rust >= 1.75 | Only for source builds |
+| Rust 1.95.0 | Source builds (`rust-toolchain.toml` selects it automatically) |
 
 ## Installation
 
@@ -270,7 +270,7 @@ brew install openkakao-cli
 
 ```bash
 git clone https://github.com/JungHoonGhae/openkakao-cli.git
-cd openkakao/openkakao-cli
+cd openkakao-cli
 cargo install --path .
 ```
 

--- a/README.en.md
+++ b/README.en.md
@@ -94,10 +94,14 @@ openkakao-cli ax-watch --hook-cmd 'my-script.sh'
 #    own sent messages are excluded (no login, no server contact)
 openkakao-cli notif-watch --json
 openkakao-cli notif-watch --hook-keyword 'urgent' --hook-cmd 'my-script.sh'
+# Also process messages that arrived while the watcher was down and remain in Notification Center
+openkakao-cli notif-watch --replay-existing --json
+# Recommended for long-running jobs: persist before delivery and retry after restart
+openkakao-cli notif-watch --durable --json
 ```
 
 > [!TIP]
-> **`ax-watch` vs `notif-watch`** — both detect incoming messages without login. `notif-watch` reads the macOS Notification Center DB (a plaintext SQLite), so it **works even when the KakaoTalk window is closed, minimized, or on another Space**, and since notifications only fire for received messages it **excludes your own sends automatically**. The trade-off: **muted / notifications-off chats** and the **chat you're currently focused on** post no notification, so they aren't seen, and it's a forward-only live stream (not history). Run `ax-watch` alongside it if you need those chats with the window open. Events are NDJSON with `event_type`, `chat_name`, `chat_id` (room id), `log_id` (message id), `message`, `attachment`, `received_at`.
+> **`ax-watch` vs `notif-watch`** — both detect incoming messages without login. `notif-watch` reads the macOS Notification Center DB (a plaintext SQLite), so it **works even when the KakaoTalk window is closed, minimized, or on another Space**, and since notifications only fire for received messages it **excludes your own sends automatically**. Existing notifications only establish a baseline by default; pass `--replay-existing` to process retained notifications that arrived while the watcher was down. For long-running jobs, prefer `--durable`: it persists events to `~/.config/openkakao/receive_inbox.db`, atomically leases each event to one worker, and retries failures with exponential backoff. After eight failures an event is quarantined so later events can proceed; terminal records missing from Notification Center are pruned after a 24-hour grace period. Delivery is **at least once** (use `chat_id` + `log_id` as the downstream idempotency key). The trade-off: **muted / notifications-off chats** and the **chat you're currently focused on** post no notification, so they aren't seen, and messages already removed from Notification Center cannot be replayed. Run `ax-watch` alongside it if you need those chats with the window open. Events are NDJSON with `event_type`, `chat_name`, `chat_id` (room id), `log_id` (message id), `message`, `attachment`, `received_at`.
 
 ### Server-login path (mostly broken right now)
 
@@ -131,9 +135,14 @@ openkakao-cli members <chat_id> --rest
 ### For Agent
 
 ```bash
-# Login-free read + write (no server contact, AX-based)
+# Login-free read (no server contact, AX-based)
 openkakao-cli ax-read "chat display name" -n 20 --json
-openkakao-cli local-send "chat display name" "message" -y --json
+
+# Agents persist a proposal; this never sends
+openkakao-cli --no-prefix safe-send propose "chat display name" "message" \
+  --reply-chat-id 42 --reply-log-id 99 \
+  --idempotency-key 'reply:42:99:policy-v1' --json
+openkakao-cli safe-send list --json
 
 # Structured output
 openkakao-cli --json chats
@@ -170,6 +179,7 @@ npx skills add JungHoonGhae/skills@openkakao-cli
 - Send to memo chat with `send --me` for quick testing
 - LOCO write ops disabled by default — opt in with `safety.allow_loco_write = true`
 - `local-send` also disabled by default — opt in with `safety.allow_ax_send = true` plus a `safety.allowed_send_chats` allowlist
+- Prefer `safe-send` for agent-driven sends — proposals only touch a local outbox and actual approval requires both a human at an interactive terminal and macOS Touch ID/login-password authentication
 
 ## Where It Fits
 
@@ -189,7 +199,7 @@ To protect your account, commands that write to the server require explicit opt-
 allow_loco_write = true
 ```
 
-`local-send` (AX-based real sending) is also disabled by default as of v1.4.0, and needs its own opt-in plus a **chat allowlist**. `local-send` matches chats by exact display-name text in the chat list, and there is no chat-id left to cross-check the target against, so the allowlist is the only guard against sending to the wrong chat:
+`local-send` (AX-based real sending) is also disabled by default as of v1.4.0, and needs its own opt-in plus a **chat allowlist**. There is no chat-id left to cross-check the target against, so a real send combines the allowlist with a unique exact-name match in the chat list, KakaoTalk code-signature verification, and macOS user authentication immediately before sending:
 
 ```toml
 # ~/.config/openkakao/config.toml
@@ -197,6 +207,27 @@ allow_loco_write = true
 allow_ax_send = true
 allowed_send_chats = ["your memo chat's display name", "another allowed chat"]
 ```
+
+For agents and automation, prefer `safe-send` over a direct `local-send -y`:
+
+```bash
+# 1. Persist a proposal only — this command can never send
+openkakao-cli safe-send propose "chat display name" "message to review"
+
+# 2. Inspect proposed and uncertain intents
+openkakao-cli safe-send list
+
+# 3. A human reviews the exact target/message, types the 12-character code,
+#    then approves with macOS Touch ID or the login password
+openkakao-cli safe-send approve <intent_id>
+
+# Discard an intent
+openkakao-cli safe-send cancel <intent_id>
+```
+
+Proposals expire after 15 minutes and live in `~/.config/openkakao/safe_send_outbox.db` with `0600` permissions. Approval has no unattended bypass: it requires both the interactive 12-character code and macOS device-owner authentication. A direct real `local-send` requires the same OS authentication. The outbox enforces at least 10 seconds between claims, 3 sends per chat per hour, 10 globally per hour, and 20 globally per day. A failure proven to occur before the final Return key is classified as `not_sent`, so the proposal can be reviewed again; an ambiguous result after Return may have been delivered, or an interrupted execution, becomes `uncertain` and is never retried automatically. The running process must have KakaoTalk's official bundle/team code signature, the chat list must contain one unique exact-name row, and a non-empty composer is refused. The selected row and composer are read back immediately before Return, and completion is verified only when the composer clears and an additional exact-text **outgoing** bubble appears.
+
+This path is implemented directly with macOS Accessibility/CoreGraphics inside `openkakao-cli`. Orca and agent `$computer-use` skills are not installation or runtime dependencies; agents use the domain-level `safe-send propose` plus human approval instead of generic UI click or keyboard actions.
 
 Read-only operations are always available:
 
@@ -212,6 +243,7 @@ Read-only operations are always available:
 | `read <id> --rest` | Read messages via REST | REST |
 | `send ... --dry-run` | Preview send without executing | None |
 | `local-send ... --dry-run` | Preview an AX send without executing | None |
+| `safe-send propose/list` | Persist or inspect send proposals (never sends) | None |
 
 > [!NOTE]
 > `local-send`/`ax-read`/`ax-watch` need to find KakaoTalk's **main chat-list window** via the macOS Accessibility API. If that window is **minimized**, or on a different **macOS Space** (virtual desktop) than the one you're currently viewing, it won't be found — restoring it automatically isn't possible without risking a stolen foreground focus, so these commands give a clear error and ask you to restore it by hand instead. If this keeps happening, a one-time fix is: right-click the KakaoTalk Dock icon → Options → Assign To → All Desktops.

--- a/README.md
+++ b/README.md
@@ -92,10 +92,14 @@ openkakao-cli ax-watch --hook-cmd 'my-script.sh'
 #    창을 안 띄워도 동작하고, 자기가 보낸 메시지는 배제됩니다 (로그인·서버 접촉 없음)
 openkakao-cli notif-watch --json
 openkakao-cli notif-watch --hook-keyword '긴급' --hook-cmd 'my-script.sh'
+# 감시가 꺼져 있던 동안 도착해 알림 센터에 남은 메시지도 시작 즉시 처리
+openkakao-cli notif-watch --replay-existing --json
+# 장기 실행 권장: 전달 전 로컬 인박스에 저장하고 재시작 후 미전달 이벤트 재시도
+openkakao-cli notif-watch --durable --json
 ```
 
 > [!TIP]
-> **`ax-watch` vs `notif-watch`** — 둘 다 로그인 없이 수신을 감지합니다. `notif-watch`는 macOS 알림 센터 DB(평문 SQLite)를 읽으므로 **카카오톡 창이 닫혀/최소화돼 있거나 다른 Space에 있어도 동작**하고, 알림은 수신에만 뜨므로 **자기 발신을 자동으로 배제**합니다. 대신 **음소거·알림 끈 방**이나 **지금 포커스 중인 방**은 알림이 안 떠 감지하지 못하고, 히스토리가 아닌 전진형 라이브 스트림입니다. 창을 열어두고 그 방들까지 잡아야 하면 `ax-watch`를 병행하세요. 이벤트는 `event_type`, `chat_name`, `chat_id`(방ID), `log_id`(메시지ID), `message`, `attachment`, `received_at`를 담은 NDJSON입니다.
+> **`ax-watch` vs `notif-watch`** — 둘 다 로그인 없이 수신을 감지합니다. `notif-watch`는 macOS 알림 센터 DB(평문 SQLite)를 읽으므로 **카카오톡 창이 닫혀/최소화돼 있거나 다른 Space에 있어도 동작**하고, 알림은 수신에만 뜨므로 **자기 발신을 자동으로 배제**합니다. 기본으로 시작 전 알림은 기준선으로만 삼으며, 감시 중단 사이의 알림까지 처리하려면 `--replay-existing`을 명시하세요. 장기 실행에는 `--durable`을 권장합니다. 이 모드는 이벤트를 `~/.config/openkakao/receive_inbox.db`에 먼저 저장하고 원자적 lease로 한 worker만 처리하며, 실패 시 지수 backoff로 재시도합니다. 8회 실패한 이벤트는 격리해 뒤 이벤트를 막지 않고, Notification Center에서 사라진 완료·격리 기록은 24시간 유예 후 정리합니다. 전달 의미론은 **at-least-once**입니다(외부 처리는 `chat_id`+`log_id`를 멱등 키로 쓰세요). 대신 **음소거·알림 끈 방**이나 **지금 포커스 중인 방**은 알림이 안 떠 감지하지 못하고, Notification Center에서 이미 삭제된 메시지는 재생할 수 없습니다. 창을 열어두고 그 방들까지 잡아야 하면 `ax-watch`를 병행하세요. 이벤트는 `event_type`, `chat_name`, `chat_id`(방ID), `log_id`(메시지ID), `message`, `attachment`, `received_at`를 담은 NDJSON입니다.
 
 ### 서버 로그인 기반 (현재 대부분 깨짐)
 
@@ -129,9 +133,14 @@ openkakao-cli members <chat_id> --rest
 ### For Agent
 
 ```bash
-# 로그인 없이 읽고 쓰기 (서버 통신 없음, AX 기반)
+# 로그인 없이 읽기 (서버 통신 없음, AX 기반)
 openkakao-cli ax-read "채팅방 표시 이름" -n 20 --json
-openkakao-cli local-send "채팅방 표시 이름" "message" -y --json
+
+# 에이전트는 전송하지 않고 영속 제안만 생성
+openkakao-cli --no-prefix safe-send propose "채팅방 표시 이름" "message" \
+  --reply-chat-id 42 --reply-log-id 99 \
+  --idempotency-key 'reply:42:99:policy-v1' --json
+openkakao-cli safe-send list --json
 
 # 실행 전 미리보기
 openkakao-cli send <chat_id> "message" --dry-run --json
@@ -168,6 +177,7 @@ npx skills add JungHoonGhae/skills@openkakao-cli
 - `send --me`로 나와의 채팅에 바로 전송 (테스트용)
 - LOCO write 기본 비활성 — `safety.allow_loco_write = true`로 opt-in
 - `local-send`도 기본 비활성 — `safety.allow_ax_send = true` + `safety.allowed_send_chats` 화이트리스트로 opt-in
+- 에이전트 전송에는 `safe-send` 권장 — 제안은 로컬 Outbox에만 저장되고 실제 승인은 사람의 대화형 터미널과 macOS Touch ID/로그인 암호 인증을 모두 요구
 
 ## 이런 경우에 잘 맞습니다
 
@@ -187,7 +197,7 @@ v1.1.0부터 LOCO write 작업(send, delete, edit, react)은 **기본 비활성*
 allow_loco_write = true
 ```
 
-`local-send`(AX 기반 실전송)도 v1.4.0부터 기본 비활성이며, 별도로 opt-in과 **채팅방 화이트리스트**가 필요합니다. `local-send`는 채팅 목록에서 표시 이름이 정확히 일치하는 방을 찾아 전송하는데, 로컬 DB의 chat-id로 대상을 다시 검증할 방법이 없어졌기 때문에 화이트리스트가 유일한 안전장치입니다:
+`local-send`(AX 기반 실전송)도 v1.4.0부터 기본 비활성이며, 별도로 opt-in과 **채팅방 화이트리스트**가 필요합니다. 로컬 DB의 chat-id로 대상을 다시 검증할 수 없으므로, 실전송은 화이트리스트뿐 아니라 채팅 목록의 유일한 exact-name 일치, 카카오톡 코드서명, 전송 직전 macOS 사용자 인증을 함께 요구합니다:
 
 ```toml
 # ~/.config/openkakao/config.toml
@@ -195,6 +205,27 @@ allow_loco_write = true
 allow_ax_send = true
 allowed_send_chats = ["나와의 채팅에 표시되는 이름", "다른 허용 채팅방 이름"]
 ```
+
+에이전트나 자동화에는 직접 `local-send -y` 대신 `safe-send`를 권장합니다:
+
+```bash
+# 1. 제안만 저장 — 이 명령은 절대 메시지를 보내지 않음
+openkakao-cli safe-send propose "채팅방 표시 이름" "검토할 메시지"
+
+# 2. 활성 제안과 uncertain 상태 확인
+openkakao-cli safe-send list
+
+# 3. 사람이 실제 터미널에서 대상·내용을 검토하고 12자리 코드를 입력한 뒤
+#    macOS Touch ID 또는 로그인 암호로 승인
+openkakao-cli safe-send approve <intent_id>
+
+# 폐기
+openkakao-cli safe-send cancel <intent_id>
+```
+
+제안은 15분 후 만료되며 `~/.config/openkakao/safe_send_outbox.db`(권한 `0600`)에 저장됩니다. 승인에는 unattended 우회가 없고, 대화형 터미널의 12자리 코드와 macOS device-owner 인증을 모두 통과해야 합니다. 직접 `local-send`로 실전송할 때도 같은 OS 인증이 필요합니다. 전송 claim 간 최소 10초, 방별 시간당 3건, 전체 시간당 10건·일일 20건을 넘길 수 없습니다. 최종 Return 이전에 실패했음이 확실하면 `not_sent`로 분류해 제안을 다시 검토할 수 있고, Return 이후 결과가 애매하거나 실행이 중단되면 `uncertain`으로 격리되어 자동 재시도하지 않습니다. 실행 중인 앱은 공식 KakaoTalk 번들·팀 코드서명으로 확인하고, 채팅 목록에 같은 표시 이름이 둘 이상이면 거부합니다. 선택된 행과 입력값을 Return 직전에 다시 읽어 확인하며, 입력창이 비워지면서 동일 내용의 새 **발신** 메시지 버블이 증가한 경우만 전송 완료로 인정합니다.
+
+이 경로는 `openkakao-cli`가 macOS Accessibility/CoreGraphics를 직접 호출하는 네이티브 구현입니다. Orca나 에이전트의 `$computer-use` 스킬은 설치·실행에 필요하지 않으며, 범용 UI 클릭/키 입력 대신 `safe-send propose`와 사람의 승인 interface를 사용합니다.
 
 읽기 전용 작업은 항상 사용 가능합니다:
 
@@ -210,6 +241,7 @@ allowed_send_chats = ["나와의 채팅에 표시되는 이름", "다른 허용 
 | `read <id> --rest` | REST API 메시지 읽기 | REST |
 | `send ... --dry-run` | 전송 미리보기 | 없음 |
 | `local-send ... --dry-run` | AX 전송 미리보기 | 없음 |
+| `safe-send propose/list` | 영속 전송 제안 생성·조회 (실제 전송 없음) | 없음 |
 
 > [!NOTE]
 > `local-send`/`ax-read`/`ax-watch`는 macOS Accessibility API로 카카오톡의 **메인 채팅 목록 창**을 찾아야 동작합니다. 이 창이 **최소화**돼 있거나 현재 보고 있는 것과 **다른 macOS Space(가상 데스크탑)**에 있으면 찾지 못합니다(포커스를 뺏지 않고는 자동 복구가 불가능해서, 명확한 에러만 내고 직접 복원을 요청합니다). 계속 겪는다면 Dock의 카카오톡 아이콘 우클릭 → Options → Assign To → All Desktops로 한 번만 설정해두세요.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 > **로그인 없이 바로 동작합니다.** `local-send`/`ax-read`는 macOS Accessibility API로 카카오톡 UI를 직접 읽고 조작해서, 서버 세션 없이도 실제 메시지 전송과 최근 대화 읽기를 지원합니다. KakaoTalk 앱이 실행 중이고 로그인만 되어 있으면 됩니다 — 아래 [Quick Start](#quick-start) 참고.
 
 > [!NOTE]
-> 서버 로그인(`login --save`/`login --manual`)은 최근 KakaoTalk macOS 빌드에서 대부분 동작하지 않습니다 ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15), [#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)). **미등록 기기로 로그인을 반복 시도하지 마세요** — 카카오가 계정의 "서브 디바이스 로그인"을 차단하거나 계정을 제재할 수 있습니다(실제 피해 사례가 보고되었습니다). 로컬 SQLCipher DB(`local-chats`/`local-read`/`local-search`)도 최신 빌드에서 키 유도 공식이 어긋나 신뢰할 수 없습니다 — 대신 `ax-read`를 쓰세요.
+> 서버 로그인(`login --save`/`login --manual`)은 최근 KakaoTalk macOS 빌드에서 대부분 동작하지 않습니다 ([#15](https://github.com/JungHoonGhae/openkakao-cli/issues/15), [#20](https://github.com/JungHoonGhae/openkakao-cli/issues/20), [#22](https://github.com/JungHoonGhae/openkakao-cli/issues/22)). **미등록 기기로 로그인을 반복 시도하지 마세요** — 카카오가 계정의 "서브 디바이스 로그인"을 차단하거나 계정을 제재할 수 있습니다(실제 피해 사례가 보고되었습니다). 로컬 SQLCipher DB(`local-chats`/`local-read`/`local-search`)도 최신 빌드에서 키 유도 공식이 어긋나 신뢰할 수 없습니다 — 읽기는 `ax-read`, 수신 감지는 `notif-watch`(알림 스트림, 창 무관·자기발신 배제) 또는 `ax-watch`를 쓰세요.
 
 > [!WARNING]
 > 이 프로젝트는 카카오(Kakao Corp.)와 무관한 비공식 CLI입니다. 연구, 자동화, 로컬 워크플로 용도로 만들었고, 카카오의 승인이나 보증을 받지 않았습니다.
@@ -85,9 +85,17 @@ openkakao-cli local-send "채팅방 표시 이름" "Hello from CLI!" -y         
 # 3. 최근 메시지 읽기 — 같은 방식(AX)으로 화면에 보이는 메시지를 스크랩
 openkakao-cli ax-read "채팅방 표시 이름" -n 20
 
-# 4. 수신 감지 — 채팅 목록을 폴링해 안읽음이 늘면 hook/webhook 발화 (서버 접촉 없음)
+# 4. 수신 감지 (AX) — 채팅 목록을 폴링해 안읽음이 늘면 hook/webhook 발화 (서버 접촉 없음)
 openkakao-cli ax-watch --hook-cmd 'my-script.sh'
+
+# 5. 수신 감지 (알림 스트림) — macOS 알림 센터 DB를 폴링해 새 메시지를 감지
+#    창을 안 띄워도 동작하고, 자기가 보낸 메시지는 배제됩니다 (로그인·서버 접촉 없음)
+openkakao-cli notif-watch --json
+openkakao-cli notif-watch --hook-keyword '긴급' --hook-cmd 'my-script.sh'
 ```
+
+> [!TIP]
+> **`ax-watch` vs `notif-watch`** — 둘 다 로그인 없이 수신을 감지합니다. `notif-watch`는 macOS 알림 센터 DB(평문 SQLite)를 읽으므로 **카카오톡 창이 닫혀/최소화돼 있거나 다른 Space에 있어도 동작**하고, 알림은 수신에만 뜨므로 **자기 발신을 자동으로 배제**합니다. 대신 **음소거·알림 끈 방**이나 **지금 포커스 중인 방**은 알림이 안 떠 감지하지 못하고, 히스토리가 아닌 전진형 라이브 스트림입니다. 창을 열어두고 그 방들까지 잡아야 하면 `ax-watch`를 병행하세요. 이벤트는 `event_type`, `chat_name`, `chat_id`(방ID), `log_id`(메시지ID), `message`, `attachment`, `received_at`를 담은 NDJSON입니다.
 
 ### 서버 로그인 기반 (현재 대부분 깨짐)
 
@@ -194,6 +202,7 @@ allowed_send_chats = ["나와의 채팅에 표시되는 이름", "다른 허용 
 |------|------|-----------|
 | `ax-read <chat_name>` | 화면에 열린 채팅의 최근 메시지 스크랩 (AX) | 없음 |
 | `ax-watch` | 채팅 목록을 폴링해 안읽음 증가 시 hook/webhook 발화 (AX, 로그인 불필요) | 없음 |
+| `notif-watch` | macOS 알림 센터 DB를 폴링해 새 수신 메시지 감지 — 창 무관·자기발신 배제 (로그인 불필요) | 없음 |
 | `local-chats` | 로컬 DB 채팅 목록 (최신 빌드에서 신뢰 불가) | 없음 |
 | `local-read <id>` | 로컬 DB 메시지 읽기 (최신 빌드에서 신뢰 불가) | 없음 |
 | `local-search "keyword"` | 로컬 DB 검색 (최신 빌드에서 신뢰 불가) | 없음 |
@@ -204,6 +213,8 @@ allowed_send_chats = ["나와의 채팅에 표시되는 이름", "다른 허용 
 
 > [!NOTE]
 > `local-send`/`ax-read`/`ax-watch`는 macOS Accessibility API로 카카오톡의 **메인 채팅 목록 창**을 찾아야 동작합니다. 이 창이 **최소화**돼 있거나 현재 보고 있는 것과 **다른 macOS Space(가상 데스크탑)**에 있으면 찾지 못합니다(포커스를 뺏지 않고는 자동 복구가 불가능해서, 명확한 에러만 내고 직접 복원을 요청합니다). 계속 겪는다면 Dock의 카카오톡 아이콘 우클릭 → Options → Assign To → All Desktops로 한 번만 설정해두세요.
+>
+> **`notif-watch`는 이 제약을 받지 않습니다** — AX 창이 아니라 macOS 알림 센터 DB를 읽으므로 창 상태와 무관하게 동작합니다(대신 음소거·포커스 중인 방은 알림이 안 떠 감지 못함).
 
 ## 요구 사항
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <p align="center">
   <a href="https://github.com/JungHoonGhae/openkakao-cli/stargazers"><img src="https://img.shields.io/github/stars/JungHoonGhae/openkakao-cli" alt="GitHub stars" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="MIT License" /></a>
-  <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/Rust-1.75+-orange.svg" alt="Rust" /></a>
+  <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/Rust-1.95-orange.svg" alt="Rust" /></a>
   <a href="https://openkakao.vercel.app/"><img src="https://img.shields.io/badge/status-active-brightgreen" alt="Status Active" /></a>
   <a href="https://openkakao.vercel.app/"><img src="https://img.shields.io/badge/docs-fumadocs-black" alt="Docs" /></a>
 </p>
@@ -253,7 +253,7 @@ openkakao-cli safe-send cancel <intent_id>
 | Requirement | Notes |
 |-------------|-------|
 | macOS | 카카오톡 데스크탑 앱 설치 및 로그인 필요 |
-| Rust >= 1.75 | 소스 빌드 시 |
+| Rust 1.95.0 | 소스 빌드 시 (`rust-toolchain.toml`에서 자동 선택) |
 
 ## 설치
 
@@ -268,7 +268,7 @@ brew install openkakao-cli
 
 ```bash
 git clone https://github.com/JungHoonGhae/openkakao-cli.git
-cd openkakao/openkakao-cli
+cd openkakao-cli
 cargo install --path .
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,11 +20,51 @@ body, the room/sender name, a `<room_id>_<msg_id>` identity, a timestamp, and
   notification).
 - Read-only and local: no server contact, no ban risk, no focus stealing, no
   login, no DB decryption.
+- By default, retained notifications establish a no-flood startup baseline;
+  `--replay-existing` explicitly processes messages still retained from watcher
+  downtime, with `(room_id, msg_id)` deduplication.
+- `--durable` is the long-running mode: it records each event in a private
+  openkakao-owned SQLite inbox before delivery, atomically leases work across
+  concurrent processes, automatically reconciles retained notifications after
+  restart, and retries failed or rate-limited sinks with capped exponential
+  backoff and at-least-once semantics. Eight failed attempts quarantine one
+  event so it cannot block later work; terminal tombstones are pruned after a
+  24-hour grace period once Notification Center no longer retains the source.
+- A per-user `launchd` example (`examples/launchd/com.openkakao.notif-watch.plist`)
+  supervises the durable receiver with `RunAtLoad`, `KeepAlive`, and restart
+  throttling.
 
 Structural limits (documented): muted / notifications-off chats and the chat
 you're currently focused on post no notification, so they aren't seen; it's a
 forward-only live stream, not history. `ax-watch` complements it for those
 chats when the window is open.
+
+## Safe outbound: proposal-first AX sending (`safe-send`)
+
+Agent-originated replies use a durable `SafeSendOutbox` instead of invoking AX
+directly. `propose` is local-only and idempotent when given a source-event key;
+`approve` is interactive-only and claims the immutable target/message before
+calling the AX adapter. The proposal code is followed by macOS device-owner
+authentication, and direct real `local-send` uses the same OS boundary.
+Successful verification becomes `sent`. Adapter errors, process interruption,
+or an indeterminate completion after Return may have been pressed become
+`uncertain` and are never retried automatically. A failure proven to happen
+before that commit point returns to `proposed` for another explicit review.
+Native AX verification authenticates KakaoTalk's bundle/team code signature,
+requires one unique exact-name row, refuses existing drafts, reads the selected
+row and composer value back before commit, and requires both a cleared composer
+and an additional exact-text outgoing message bubble afterward. A five-minute
+sending lease distinguishes a live concurrent execution from a crashed process,
+while conservative per-chat and global budgets limit damage even after explicit
+approval.
+
+The production send path calls macOS Accessibility/CoreGraphics directly. Orca
+and agent `computer-use` skills may be used as read-only development diagnostics,
+but are not runtime dependencies and are never part of approval or delivery.
+
+This improves delivery safety but cannot create an authoritative target
+identity: current KakaoTalk builds do not expose a usable chat id to the AX
+sender, so exact display-name allowlisting and ambiguity refusal remain required.
 
 ## Sealed: local DB tailing (SQLCipher) — NO-GO on current builds
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,33 +1,44 @@
 # Roadmap
 
-## North star: local DB tailing (replaces AX polling for receive detection)
+## Receive detection: notification-stream watching (`notif-watch`)
 
-`ax-watch` today polls the KakaoTalk chat list via the macOS Accessibility API
-and infers "a new message arrived" from list-level signals (unread count,
-message preview). That is a lossy proxy with known limits: it needs the main
-window open/visible on the active Space, only sees loaded chat rows, and can't
-cleanly tell your own sends from incoming messages.
+`ax-watch` polls the KakaoTalk chat list via the macOS Accessibility API and
+infers "a new message arrived" from list-level signals (unread count, preview).
+That is a lossy proxy: it needs the main window open/visible on the active
+Space, only sees loaded chat rows, and can't cleanly tell your own sends from
+incoming messages.
 
-The complete long-term answer is to stop inferring and read the actual message
-stream from KakaoTalk's local SQLCipher DB, which stores every message with a
-monotonic `log_id`:
+The landed answer is **`notif-watch`**: poll the macOS Notification Center DB
+(`~/Library/Group Containers/group.com.apple.usernoted/db2/db`, plaintext
+SQLite, read-only) for KakaoTalk notifications. Each payload carries the message
+body, the room/sender name, a `<room_id>_<msg_id>` identity, a timestamp, and
+(for images) the local attachment path.
 
-- A watcher tails `log_id > last_seen` and emits exact message events
-  (author, text, timestamp, chat_id) — no unread/preview heuristics.
-- Works for **all** chats regardless of window state (closed, minimized, on
-  another Space) — the window-visibility requirement disappears entirely.
-- Distinguishes self vs. incoming perfectly; no false positives.
-- Read-only and local: no server contact, no ban risk, no focus stealing.
+- Works for chats regardless of window state (closed, minimized, on another
+  Space) — the window-visibility requirement disappears.
+- Distinguishes self vs. incoming perfectly (a message you send posts no
+  notification).
+- Read-only and local: no server contact, no ban risk, no focus stealing, no
+  login, no DB decryption.
 
-When this lands, `ax-watch` becomes a fallback rather than the primary path.
+Structural limits (documented): muted / notifications-off chats and the chat
+you're currently focused on post no notification, so they aren't seen; it's a
+forward-only live stream, not history. `ax-watch` complements it for those
+chats when the window is open.
 
-**Blocker:** the DB key-derivation formula changed in recent KakaoTalk macOS
-builds (observed on 26.5.0 — the derived filename/key no longer matches
-on-disk), so decryption currently fails even though userId and device UUID are
-recovered. Reaching this north star requires reverse-engineering the current
-key derivation, and it may need redoing on future KakaoTalk builds.
+## Sealed: local DB tailing (SQLCipher) — NO-GO on current builds
 
-## If the DB stays sealed: message-bubble diffing (AX, Tier 2)
+The originally-planned north star — tailing the local SQLCipher message DB by
+`log_id` — is **NO-GO** on KakaoTalk macOS 26.5.0+ and is not being pursued.
+Findings (see `docs/research/db-key-derivation.md`, issues #40 / #43): the DB
+name and key are no longer a derivable PBKDF2 recipe but values stored
+AES-encrypted via NTSetting; a dynamic hook is blocked because re-signing the
+app to attach a debugger loses its Keychain access and it logs itself out, so it
+never opens the message DB offline. Recovering the key would require either
+disabling SIP to debug the untouched app, or reversing the NTSetting AES store —
+neither pursued. If a future build reopens this, it returns as a fresh effort.
+
+## If notification coverage isn't enough: message-bubble diffing (AX, Tier 2)
 
 The correct AX-only way to also catch messages in a chat you keep open (where
 the unread count stays 0) is to track the actual message **bubbles** in each

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,14 @@
+fn main() {
+    println!("cargo:rerun-if-changed=native/macos_user_presence.m");
+
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        cc::Build::new()
+            .file("native/macos_user_presence.m")
+            .flag("-fobjc-arc")
+            .flag("-fblocks")
+            .compile("openkakao_user_presence");
+        println!("cargo:rustc-link-lib=framework=Foundation");
+        println!("cargo:rustc-link-lib=framework=LocalAuthentication");
+        println!("cargo:rustc-link-lib=framework=Security");
+    }
+}

--- a/docs/research/local-receive-strategy.md
+++ b/docs/research/local-receive-strategy.md
@@ -1,0 +1,289 @@
+# Login-free, local-only KakaoTalk receive strategy on macOS
+
+Status: research note (internal). Last checked on **2026-09-02**, including a
+read-only schema check on macOS **26.5.2**. No KakaoTalk message content was read
+for this research.
+
+## Question
+
+What is the most complete receive path openkakao-cli can implement without a
+LOCO/REST login or server contact, and where are the unavoidable gaps?
+
+Here, **login-free** means that openkakao-cli does not establish its own Kakao
+server session. KakaoTalk itself still has to be installed, signed in, and able
+to receive messages. It does not mean reception while the macOS user is logged
+out.
+
+## Headline verdict
+
+There is no public macOS API that lets one process subscribe to another app's
+delivered user notifications. Apple's API returns only **your app's** delivered
+notifications that are still present in Notification Center
+([`UNUserNotificationCenter`](https://developer.apple.com/documentation/usernotifications/unusernotificationcenter),
+[`getDeliveredNotifications`](https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/getdeliverednotifications%28completionhandler%3A%29)).
+
+The best feasible design is therefore a **best-effort fusion**, not a single
+lossless source:
+
+1. Notification Center DB polling as the primary, window-independent signal.
+2. `AXObserver`-triggered Accessibility snapshots plus low-rate polling as the
+   complementary signal for notification-suppressed/open chats.
+3. A per-user `launchd` LaunchAgent for restart and login-session lifecycle.
+4. A durable local inbox/dedup ledger so process restarts do not turn retained
+   notification replay into duplicates.
+
+This can materially improve the current implementation, but **100% lossless or
+exactly-once receive is impossible** without a Kakao-supported receive API or a
+readable authoritative message database.
+
+## Feasibility matrix
+
+| Candidate | Public/stable contract | Coverage and recovery | Verdict |
+|---|---|---|---|
+| Cross-app `UNUserNotificationCenter` | Public, but app-scoped | Cannot read or subscribe to KakaoTalk notifications | **NO-GO** |
+| `usernoted` Notification Center SQLite | Path/schema/payload are private implementation details | Strongest window-independent local signal; replay only while a record remains | **Primary, best-effort** |
+| AX chat-list polling | Public AX API with user-granted Accessibility trust | Visible/loaded rows; unread count and latest preview, not an event log | **Fallback/reconciliation** |
+| `AXObserver` on KakaoTalk elements | Public API, but event support depends on the observed app/element | Low-latency wake-up while the target PID and AX elements exist; no replay | **Trigger, not source of truth** |
+| AX message-bubble diffing | Public AX reads; KakaoTalk hierarchy is app-version-specific | Can cover already-open chats where unread stays zero; only rendered bubbles | **Tier 2 complement** |
+| Distributed notifications | Public cooperative IPC | Useful only if KakaoTalk explicitly posts a known event; delivery may be delayed/dropped | **Not a receive path today** |
+| Local SQLCipher message DB | Would be authoritative if readable | Current KakaoTalk builds keep the key behind an unresolved encrypted store | **Current NO-GO**; see [DB research](db-key-derivation.md) |
+| `launchd` `KeepAlive` | Public process supervision | Restarts the watcher, but does not retain missed events or guarantee no restart gap | **Supervisor only** |
+
+## 1. Cross-app notification subscription: no public API
+
+**Sourced fact.** `UNUserNotificationCenter` is the central object for notification
+behavior in “your app or app extension,” and its delivered-notification query is
+explicitly limited to “your app's” notifications still visible in Notification
+Center ([class documentation](https://developer.apple.com/documentation/usernotifications/unusernotificationcenter),
+[delivered-notification query](https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/getdeliverednotifications%28completionhandler%3A%29)).
+Its delegate processes notifications arriving for the owning app and user actions
+on those notifications, not another app's stream
+([`UNUserNotificationCenterDelegate`](https://developer.apple.com/documentation/usernotifications/unusernotificationcenterdelegate)).
+
+**Conclusion.** A helper app, CLI, notification service extension, or LaunchAgent
+cannot use public UserNotifications API to subscribe to KakaoTalk's delivered
+notifications. Reading `usernoted` storage is not a hidden use of that API; it is
+an unsupported dependency on system implementation details.
+
+## 2. Notification Center DB: useful current state, not a queue
+
+**Sourced fact.** Apple's only public retention statement is presence-based:
+delivered notifications are returned while they are still present/visible in
+Notification Center. Users can clear one notification or an entire stack
+([Notification Center user guide](https://support.apple.com/guide/mac-help/get-notifications-mchl2fb1258f/mac)).
+macOS also lets users disable an app's notifications, exclude them from
+Notification Center, hide previews, or choose temporary versus persistent alerts;
+even “persistent” means until the user dismisses it
+([Notifications settings](https://support.apple.com/guide/mac-help/notifications-settings-mh40583/mac)).
+
+**Local observation, not an API contract.** On macOS 26.5.2 the file currently at
+`~/Library/Group Containers/group.com.apple.usernoted/db2/db` is a plaintext,
+WAL-mode SQLite database with `app` and `record` tables matching the current
+[`notif-watch` query](../../src/commands/notif_watch.rs#L217-L260). Apple publishes
+no contract for this path, schema, record lifetime, or binary-plist payload.
+Consequently an OS update may move it or change any of those details.
+
+The existing choice to open with `mode=ro` and include the WAL is sound for this
+unsupported path: SQLite defines `mode=ro` as read-only, permits read-only access
+to WAL databases when its side files are available, and gives readers a committed
+snapshot
+([URI filenames](https://www.sqlite.org/uri.html),
+[WAL read-only rules](https://www.sqlite.org/wal.html#readonly),
+[SQLite isolation](https://www.sqlite.org/isolation.html)).
+
+**Inference.** Treat this DB as a snapshot cache, never as durable history:
+
+- A notification created and removed between two polls can be missed.
+- A user clear, app replacement/removal, or OS cleanup before restart makes replay
+  impossible.
+- Notification grouping may leave several records today, but it is not a retention
+  guarantee.
+- Hidden previews can preserve an identifier while withholding message content.
+- Schema or payload mismatch must disable this sensor cleanly, not crash-loop the
+  whole receive service.
+
+The current `--replay-existing` improves restart recovery only for records still
+retained. Its in-memory tracker is bounded to the previous snapshot
+([tracker](../../src/commands/notif_watch.rs#L154-L193)); therefore a supervised,
+always-replay process also needs a **persistent** dedup ledger across restarts.
+
+## 3. Accessibility observers: event hints, then read and diff
+
+**Sourced fact.** `AXObserverCreate` creates an observer for one application PID,
+and `AXObserverAddNotification` registers a particular notification on a particular
+AX element
+([create](https://developer.apple.com/documentation/applicationservices/1460133-axobservercreate),
+[register](https://developer.apple.com/documentation/applicationservices/1462089-axobserveraddnotification)).
+The observer's run-loop source must be installed before callbacks can arrive
+([`AXObserverGetRunLoopSource`](https://developer.apple.com/documentation/applicationservices/1459139-axobservergetrunloopsource)).
+The caller must be a trusted Accessibility client
+([`AXIsProcessTrustedWithOptions`](https://developer.apple.com/documentation/applicationservices/1459186-axisprocesstrustedwithoptions)).
+
+Apple defines useful change notifications including value, row-count, layout,
+creation, destruction, and window changes
+([AX notification list](https://developer.apple.com/documentation/applicationservices/carbon_accessibility/notifications),
+[`kAXLayoutChangedNotification`](https://developer.apple.com/documentation/applicationservices/kaxlayoutchangednotification)).
+However, registration can return `kAXErrorNotificationUnsupported`; Apple also
+explains that standard AppKit controls post appropriate events while custom
+controls must post their own
+([registration errors](https://developer.apple.com/documentation/applicationservices/1462089-axobserveraddnotification),
+[Accessibility protocol](https://developer.apple.com/documentation/appkit/nsaccessibilityprotocol)).
+
+**Inference.** `AXObserver` can replace tight polling as a wake-up mechanism, but
+cannot replace snapshot/diff logic or a watchdog poll:
+
+- The callback says that an element changed; it is not a durable Kakao message
+  event and carries no replay log.
+- KakaoTalk may not post the desired event for a custom chat row or bubble.
+- Virtualized tables may reuse rows, fold multiple arrivals into one unread/preview
+  state, or expose only rendered children.
+- App restart changes the PID; UI replacement invalidates element references and
+  requires discovery and subscription again.
+
+Register, where supported, `kAXRowCountChangedNotification`,
+`kAXLayoutChangedNotification`, `kAXValueChangedNotification`,
+`kAXCreatedNotification`, `kAXUIElementDestroyedNotification`, and the relevant
+window-change notifications. Each callback should only mark a subtree dirty and
+coalesce a near-immediate re-snapshot. Keep a slower periodic snapshot to reconcile
+missed/unsupported events.
+
+For the main chat list, diff `{chat name, unread, preview}` as today
+([`ax-watch`](../../src/commands/ax_watch.rs#L20-L30)). For every already-open chat
+window, diff the rendered message-bubble tail using the existing bubble parser
+([AX bubble reader](../../src/ax_send.rs#L527-L588)). Do **not** open rooms solely
+to watch them: opening changes read state and foreground behavior. Bubble identity
+will be heuristic until KakaoTalk exposes a stable AX identifier, so Notification
+Center `(room_id, msg_id)` identity should win whenever both sensors see the event.
+
+## 4. `launchd`: correct supervision, not delivery durability
+
+**Sourced fact.** Apple recommends a LaunchAgent for per-user background work; it
+runs in the logged-in user's context. A LaunchDaemon runs in system context, has
+no WindowServer access, and is therefore wrong for KakaoTalk AX interaction
+([creating jobs](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html),
+[agents versus daemons](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/DesigningDaemons.html)).
+
+`KeepAlive=true` asks `launchd` to keep the job running, but rapidly failing jobs
+are throttled; the documented default spawn throttle is ten seconds
+([Apple's `launchd.plist(5)` source](https://github.com/apple-oss-distributions/launchd/blob/main/man/launchd.plist.5#L1538-L1560),
+[`ThrottleInterval`](https://github.com/apple-oss-distributions/launchd/blob/main/man/launchd.plist.5#L1649-L1658)).
+For a packaged macOS helper, `SMAppService` is the supported registration surface
+([`SMAppService`](https://developer.apple.com/documentation/servicemanagement/smappservice)).
+
+**Inference.** Use a per-user LaunchAgent with `RunAtLoad` and `KeepAlive`, but
+assume non-zero gaps during crash loops, login/logout, sleep/wake, upgrades, and
+permission failures. The process needs internal backoff, a heartbeat/health state,
+and startup reconciliation. A permanent configuration or permission error should
+exit distinctly or remain degraded rather than spin every ten seconds.
+
+## 5. Distributed notifications are not Notification Center events
+
+**Sourced fact.** `DistributedNotificationCenter` is cooperative cross-process IPC:
+a process explicitly posts a named notification and registered processes receive
+it. Apple warns that latency is unbounded, queues can fill and drop notifications,
+and payloads are untrusted
+([documentation](https://developer.apple.com/documentation/foundation/distributednotificationcenter)).
+Core Foundation exposes the same kind of inter-application center and requires
+registration by notification name/object
+([`CFNotificationCenter`](https://developer.apple.com/documentation/corefoundation/cfnotificationcenter)).
+
+**Conclusion.** This is separate from user-facing UserNotifications/Notification
+Center. It becomes useful only if KakaoTalk deliberately posts a stable, known
+distributed notification for message arrival. No such contract is known. Listening
+to guessed/private names would add another lossy implementation dependency, not a
+replacement for the DB or AX sensors.
+
+## Recommended implementable architecture
+
+### A. One long-lived receive service
+
+Add a unified `receive-watch`/daemon core supervised by a per-user LaunchAgent.
+Run all sensors in one process and normalize them into the existing
+`WatchMessageEvent`; keep hooks/webhooks downstream of a local durable inbox.
+
+### B. Primary Notification DB sensor
+
+- Open read-only with WAL participation; never copy, mutate, checkpoint, or vacuum
+  Apple's DB.
+- Poll at a bounded interval (about one second is a reasonable starting point).
+  A filesystem-change signal may trigger an earlier poll, but a timer remains the
+  reconciliation path.
+- On startup and after wake/reopen, scan retained records and consult the persistent
+  ledger rather than blindly replaying all of them.
+- Version/probe the expected tables, columns, bundle identifier, and payload fields;
+  expose `healthy`, `permission_denied`, and `schema_incompatible` states.
+
+### C. Complementary AX sensor
+
+- Discover the KakaoTalk PID; attach a new observer after every launch and detach on
+  termination. App lifecycle can be tracked with `NSWorkspace` launch/terminate
+  notifications
+  ([`NSWorkspace`](https://developer.apple.com/documentation/appkit/nsworkspace)).
+- Probe each candidate AX notification and record which are supported on the
+  installed KakaoTalk version.
+- Use callbacks only to schedule a coalesced chat-list/open-window re-snapshot.
+- Reconcile periodically even when no callback fires, and re-discover subtrees after
+  layout/window/destruction events.
+- Add Tier 2 bubble-tail diffing only for already-open chat windows. Keep current
+  chat-list unread diffing for other visible rows.
+
+### D. Durable fusion and delivery
+
+Use a small openkakao-owned SQLite database, separate from Apple's DB:
+
+- `seen_notif(room_id, msg_id, received_at)` for authoritative notification IDs.
+- `seen_ax(window/chat fingerprint, bubble fingerprint, observed_at)` with a bounded
+  retention period for heuristic AX events.
+- `inbox(event_id, payload, source, state)` as a transactional outbox for hook/webhook
+  delivery.
+- Prefer a matching Notification event over AX; merge AX into it when a narrow
+  chat/time/content match exists. Do not discard an ambiguous AX event merely to
+  force exactly-once semantics.
+
+Persist before invoking external hooks. This gives at-least-once sink delivery with
+idempotency keys and prevents watcher crashes from losing an already-captured event.
+It cannot recover an event that neither sensor observed.
+
+### E. Health contract
+
+Extend `doctor --json` with independent states for Notification DB readability and
+schema, Kakao notifier registration, AX trust, Kakao PID/window visibility, observer
+support map, LaunchAgent state, last successful sample, and durable-inbox backlog.
+“Process running” must not be reported as “receive healthy” when both sensors are
+degraded.
+
+## Unavoidable blind spots
+
+- The macOS user is logged out: a per-user LaunchAgent and GUI Accessibility session
+  do not exist.
+- KakaoTalk is stopped, logged out, disconnected, or itself fails to receive.
+- KakaoTalk creates no user notification because a chat/app notification is muted or
+  disabled, the app suppresses the currently focused room, or Focus/settings suppress
+  delivery; previews may also be redacted
+  ([macOS notification settings](https://support.apple.com/guide/mac-help/notifications-settings-mh40583/mac)).
+- A notification appears and is removed before the DB sensor observes it, including
+  during sleep, downtime, permission loss, or a launchd restart gap.
+- KakaoTalk does not post a relevant AX event, replaces/virtualizes the observed
+  element, or receives several messages before the next AX snapshot.
+- The relevant chat row/bubbles are not present in the rendered AX tree; minimized,
+  off-Space, and closed windows remain constraints of the current AX path.
+- Notification DB schema/payload and KakaoTalk's AX hierarchy can change without
+  notice on OS/app upgrade.
+- Full Disk Access or Accessibility trust is revoked. AX trust is explicitly a user
+  grant checked per process; no supervisor setting can bypass it.
+
+## Recommended delivery order
+
+1. Persistent notification dedup + transactional inbox, then a LaunchAgent installer
+   and health/heartbeat reporting. This closes the largest restart/replay holes in the
+   already-landed path.
+2. `AXObserver` support probing and event-triggered chat-list reconciliation, while
+   retaining the existing watchdog poll.
+3. Already-open-window bubble diffing with conservative self/incoming classification
+   and Notification-ID fusion.
+4. A macOS/KakaoTalk compatibility fixture suite for notification payloads and AX
+   tree shapes, so private-schema drift fails visibly.
+
+Do not invest in distributed-notification guessing or claim exactly-once semantics.
+Revisit the local SQLCipher DB only if a safe, versioned key-recovery path becomes
+available; that is the only identified local source that could become authoritative.

--- a/docs/research/local-receive-strategy.md
+++ b/docs/research/local-receive-strategy.md
@@ -79,7 +79,7 @@ even “persistent” means until the user dismisses it
 **Local observation, not an API contract.** On macOS 26.5.2 the file currently at
 `~/Library/Group Containers/group.com.apple.usernoted/db2/db` is a plaintext,
 WAL-mode SQLite database with `app` and `record` tables matching the current
-[`notif-watch` query](../../src/commands/notif_watch.rs#L217-L260). Apple publishes
+[`notif-watch` query](../../src/commands/notif_watch.rs#L344-L385). Apple publishes
 no contract for this path, schema, record lifetime, or binary-plist payload.
 Consequently an OS update may move it or change any of those details.
 
@@ -150,7 +150,7 @@ missed/unsupported events.
 For the main chat list, diff `{chat name, unread, preview}` as today
 ([`ax-watch`](../../src/commands/ax_watch.rs#L20-L30)). For every already-open chat
 window, diff the rendered message-bubble tail using the existing bubble parser
-([AX bubble reader](../../src/ax_send.rs#L527-L588)). Do **not** open rooms solely
+([AX bubble reader](../../src/ax_send.rs#L860-L932)). Do **not** open rooms solely
 to watch them: opening changes read state and foreground behavior. Bubble identity
 will be heuristic until KakaoTalk exposes a stable AX identifier, so Notification
 Center `(room_id, msg_id)` identity should win whenever both sensors see the event.

--- a/examples/launchd/README.md
+++ b/examples/launchd/README.md
@@ -1,33 +1,44 @@
 # launchd
 
-Use these files as a starting point for long-running unattended OpenKakao jobs on macOS.
+Use these files as a starting point for long-running unattended OpenKakao jobs on macOS. The recommended receiver is the login-free, durable `notif-watch` LaunchAgent; the older `watch` examples require a LOCO server session and remain only for legacy setups.
 
 Recommended shape:
 
-1. copy `openkakao-watch-wrapper.sh` to a stable local path
-2. edit the command flags for your environment
-3. copy `com.openkakao.watch.plist` into `~/Library/LaunchAgents/`
-4. load it with `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.openkakao.watch.plist`
+1. Install `openkakao-cli` at `/opt/homebrew/bin/openkakao-cli` (or edit the wrapper).
+2. Grant Full Disk Access to the executable used by the LaunchAgent; terminal-only permission does not cover a separately launched job.
+3. Copy `openkakao-notif-watch-wrapper.sh` to `~/.config/openkakao/` and make it executable.
+4. Replace every `YOUR_USER` in `com.openkakao.notif-watch.plist`, then copy it into `~/Library/LaunchAgents/`.
+5. Create the log directory before bootstrap and load the agent:
+
+```bash
+mkdir -p ~/Library/Logs/openkakao
+chmod 700 ~/.config/openkakao/openkakao-notif-watch-wrapper.sh
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.openkakao.notif-watch.plist
+```
 
 Guardrails:
 
-- keep `watch` local-first unless you truly need a remote webhook
+- keep `--durable` enabled so captured events survive process restarts
 - keep `--allow-watch-side-effects` explicit
 - prefer `--hook-cmd` over `--webhook-url`
 - keep logs in `~/Library/Logs/openkakao/`
-- inspect `openkakao-cli auth-status` and `openkakao-cli doctor --loco` before assuming the service is healthy
+- use `chat_id` + `log_id` as the hook/webhook idempotency key; delivery is at least once
+- expect capped exponential retries; eight failed deliveries quarantine one event so later events continue
+- delivered/quarantined tombstones are retained for 24 hours after Notification Center stops retaining the source notification, then pruned
+- inspect `openkakao-cli doctor --json` before assuming the service is healthy
 
 Operational checks:
 
 ```bash
-launchctl print gui/$(id -u)/com.openkakao.watch
-tail -f ~/Library/Logs/openkakao/watch.stderr.log
-openkakao-cli auth-status
-openkakao-cli doctor --loco
+launchctl print gui/$(id -u)/com.openkakao.notif-watch
+tail -f ~/Library/Logs/openkakao/notif-watch.stderr.log
+openkakao-cli doctor --json
 ```
 
 Unload:
 
 ```bash
-launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.openkakao.watch.plist
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.openkakao.notif-watch.plist
 ```
+
+To add a hook or webhook, edit the wrapper and add `--unattended --allow-watch-side-effects` before `notif-watch`, then add the desired sink flags after it. This permission enables only the configured local/HTTP side effect; `notif-watch` itself never performs a Kakao write or server login.

--- a/examples/launchd/com.openkakao.notif-watch.plist
+++ b/examples/launchd/com.openkakao.notif-watch.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.openkakao.notif-watch</string>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <true/>
+
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+
+  <key>ProcessType</key>
+  <string>Background</string>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/YOUR_USER</string>
+
+  <key>StandardOutPath</key>
+  <string>/Users/YOUR_USER/Library/Logs/openkakao/notif-watch.stdout.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/Users/YOUR_USER/Library/Logs/openkakao/notif-watch.stderr.log</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/YOUR_USER/.config/openkakao/openkakao-notif-watch-wrapper.sh</string>
+  </array>
+</dict>
+</plist>

--- a/examples/launchd/openkakao-notif-watch-wrapper.sh
+++ b/examples/launchd/openkakao-notif-watch-wrapper.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+export PATH
+
+exec /opt/homebrew/bin/openkakao-cli \
+  notif-watch \
+  --durable \
+  "$@"

--- a/native/macos_user_presence.m
+++ b/native/macos_user_presence.m
@@ -1,0 +1,94 @@
+#import <Foundation/Foundation.h>
+#import <LocalAuthentication/LocalAuthentication.h>
+#import <Security/Security.h>
+#import <dispatch/dispatch.h>
+
+// Validate the code object that is actually bound to `pid`. This deliberately
+// avoids resolving and then checking a mutable filesystem path.
+// Return codes: 0 success, 10 guest lookup failed, 11 requirement/validity
+// failed, 12 signing metadata did not match KakaoTalk's expected identity.
+int openkakao_validate_kakaotalk_process(int pid) {
+    @autoreleasepool {
+        NSDictionary *attributes = @{
+            (__bridge NSString *)kSecGuestAttributePid : @(pid)
+        };
+        SecCodeRef guest = NULL;
+        OSStatus status = SecCodeCopyGuestWithAttributes(
+            NULL,
+            (__bridge CFDictionaryRef)attributes,
+            kSecCSDefaultFlags,
+            &guest);
+        if (status != errSecSuccess || guest == NULL) {
+            return 10;
+        }
+
+        CFStringRef requirement_text = CFSTR(
+            "anchor apple generic and identifier \"com.kakao.KakaoTalkMac\"");
+        SecRequirementRef requirement = NULL;
+        status = SecRequirementCreateWithString(
+            requirement_text, kSecCSDefaultFlags, &requirement);
+        if (status != errSecSuccess || requirement == NULL) {
+            CFRelease(guest);
+            return 11;
+        }
+
+        status = SecCodeCheckValidity(guest, kSecCSStrictValidate, requirement);
+        CFRelease(requirement);
+        if (status != errSecSuccess) {
+            CFRelease(guest);
+            return 11;
+        }
+
+        CFDictionaryRef signing_info = NULL;
+        status = SecCodeCopySigningInformation(
+            guest, kSecCSSigningInformation, &signing_info);
+        CFRelease(guest);
+        if (status != errSecSuccess || signing_info == NULL) {
+            return 12;
+        }
+
+        NSDictionary *info = (__bridge NSDictionary *)signing_info;
+        NSString *identifier = info[(__bridge NSString *)kSecCodeInfoIdentifier];
+        NSString *team = info[(__bridge NSString *)kSecCodeInfoTeamIdentifier];
+        BOOL matches = [identifier isEqualToString:@"com.kakao.KakaoTalkMac"] &&
+                       [team isEqualToString:@"L75WVXX68A"];
+        CFRelease(signing_info);
+        return matches ? 0 : 12;
+    }
+}
+
+// Return codes are intentionally small and stable for the Rust FFI boundary:
+// 0 success, 1 unavailable, 2 denied/cancelled, 3 timed out.
+int openkakao_authenticate_device_owner(const char *reason_utf8) {
+    @autoreleasepool {
+        LAContext *context = [[LAContext alloc] init];
+        NSError *availability_error = nil;
+        if (![context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication
+                                  error:&availability_error]) {
+            return 1;
+        }
+
+        NSString *reason = [NSString stringWithUTF8String:reason_utf8];
+        if (reason == nil) {
+            return 1;
+        }
+
+        dispatch_semaphore_t completion = dispatch_semaphore_create(0);
+        __block BOOL authenticated = NO;
+        [context evaluatePolicy:LAPolicyDeviceOwnerAuthentication
+                localizedReason:reason
+                          reply:^(BOOL success, NSError *error) {
+                              (void)error;
+                              authenticated = success;
+                              dispatch_semaphore_signal(completion);
+                          }];
+
+        dispatch_time_t deadline = dispatch_time(
+            DISPATCH_TIME_NOW, (int64_t)(120 * NSEC_PER_SEC));
+        if (dispatch_semaphore_wait(completion, deadline) != 0) {
+            [context invalidate];
+            return 3;
+        }
+        return authenticated ? 0 : 2;
+    }
+}

--- a/src/ax_send.rs
+++ b/src/ax_send.rs
@@ -32,6 +32,10 @@ pub(crate) enum ChatMatch {
     Ambiguous(usize),
 }
 
+// The non-macOS transport always returns an error before it can construct an
+// outcome, but callers still match this shared API so cross-platform builds
+// need the variants available.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum AxDeliveryOutcome {
     Verified,

--- a/src/ax_send.rs
+++ b/src/ax_send.rs
@@ -32,6 +32,19 @@ pub(crate) enum ChatMatch {
     Ambiguous(usize),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AxDeliveryOutcome {
+    Verified,
+    Uncertain { reason: String },
+}
+
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DeliveryObservation {
+    pub text: String,
+    pub outgoing: bool,
+}
+
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub(crate) fn match_chat_row(row_names: &[Option<String>], target: &str) -> ChatMatch {
     let mut matches = row_names
@@ -50,6 +63,29 @@ pub(crate) fn match_chat_row(row_names: &[Option<String>], target: &str) -> Chat
             ChatMatch::Ambiguous(count)
         }
     }
+}
+
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub(crate) fn has_new_exact_outgoing_message(
+    before: &[DeliveryObservation],
+    after: &[DeliveryObservation],
+    target: &str,
+) -> bool {
+    let matches_target =
+        |observation: &&DeliveryObservation| observation.outgoing && observation.text == target;
+    let before_count = before.iter().filter(matches_target).count();
+    let after_count = after.iter().filter(matches_target).count();
+    after_count > before_count
+}
+
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub(crate) fn is_verified_delivery(
+    before: &[DeliveryObservation],
+    after: &[DeliveryObservation],
+    target: &str,
+    composer_value: Option<&str>,
+) -> bool {
+    composer_value == Some("") && has_new_exact_outgoing_message(before, after, target)
 }
 
 #[cfg(test)]
@@ -97,28 +133,105 @@ mod match_tests {
         let names = [None, Some("Alice".to_string()), None];
         assert_eq!(match_chat_row(&names, "Alice"), ChatMatch::Found(1));
     }
+
+    #[test]
+    fn delivery_verification_requires_a_new_exact_message() {
+        let before = vec![
+            DeliveryObservation {
+                text: "same message".to_string(),
+                outgoing: true,
+            },
+            DeliveryObservation {
+                text: "older".to_string(),
+                outgoing: false,
+            },
+        ];
+        let unchanged = before.clone();
+        let mut appended = before.clone();
+        appended.push(DeliveryObservation {
+            text: "same message".to_string(),
+            outgoing: true,
+        });
+
+        assert!(!has_new_exact_outgoing_message(
+            &before,
+            &unchanged,
+            "same message"
+        ));
+        assert!(has_new_exact_outgoing_message(
+            &before,
+            &appended,
+            "same message"
+        ));
+
+        let mut incoming = before.clone();
+        incoming.push(DeliveryObservation {
+            text: "same message".to_string(),
+            outgoing: false,
+        });
+        assert!(!has_new_exact_outgoing_message(
+            &before,
+            &incoming,
+            "same message"
+        ));
+    }
+
+    #[test]
+    fn delivery_verification_also_requires_the_composer_to_clear() {
+        let before = vec![DeliveryObservation {
+            text: "older".to_string(),
+            outgoing: false,
+        }];
+        let after = vec![
+            before[0].clone(),
+            DeliveryObservation {
+                text: "new message".to_string(),
+                outgoing: true,
+            },
+        ];
+
+        assert!(!is_verified_delivery(
+            &before,
+            &after,
+            "new message",
+            Some("new message")
+        ));
+        assert!(is_verified_delivery(
+            &before,
+            &after,
+            "new message",
+            Some("")
+        ));
+        assert!(!is_verified_delivery(&before, &after, "new message", None));
+    }
 }
 
 #[cfg(target_os = "macos")]
 mod imp {
 
+    use std::collections::HashSet;
     use std::process::Command;
     use std::thread::sleep;
     use std::time::{Duration, Instant};
 
     use accessibility::{AXAttribute, AXUIElement, AXUIElementAttributes};
     use accessibility_sys::kAXPressAction;
-    use accessibility_sys::AXIsProcessTrusted;
-    use accessibility_sys::{AXUIElementCopyMultipleAttributeValues, AXUIElementRef};
+    use accessibility_sys::{
+        kAXValueTypeCGPoint, kAXValueTypeCGSize, AXIsProcessTrusted,
+        AXUIElementCopyMultipleAttributeValues, AXUIElementRef, AXValueGetTypeID, AXValueGetValue,
+        AXValueRef,
+    };
     use anyhow::{anyhow, Context, Result};
     use core_foundation::array::{CFArray, CFArrayRef};
-    use core_foundation::base::{CFType, TCFType};
+    use core_foundation::base::{CFEqual, CFType, TCFType};
     use core_foundation::boolean::CFBoolean;
     use core_foundation::string::CFString;
     use core_graphics::event::CGEvent;
     use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
+    use core_graphics::geometry::{CGPoint, CGSize};
 
     const KAKAOTALK_BUNDLE_ID: &str = "com.kakao.KakaoTalkMac";
+    const KAKAOTALK_TEAM_ID: &str = "L75WVXX68A";
     const RETURN_KEYCODE: u16 = 36;
     const OPEN_CHAT_TIMEOUT: Duration = Duration::from_secs(5);
     // Scoped delivery verification: a single already-open window's bubbles show
@@ -126,8 +239,14 @@ mod imp {
     // app-wide scan). Normally succeeds on the first poll.
     const VERIFY_TIMEOUT: Duration = Duration::from_secs(3);
     const VERIFY_POLL_INTERVAL: Duration = Duration::from_millis(200);
+    const COMPOSER_VERIFY_TIMEOUT: Duration = Duration::from_secs(1);
+    const COMPOSER_VERIFY_POLL_INTERVAL: Duration = Duration::from_millis(50);
+    const SNAPSHOT_MAX_DEPTH: usize = 128;
+    const SNAPSHOT_MAX_NODES: usize = 20_000;
+    const SNAPSHOT_MAX_DURATION: Duration = Duration::from_secs(5);
+    const AX_MESSAGE_TIMEOUT_SECS: f32 = 1.0;
 
-    /// Find the running KakaoTalk process id via `pgrep -x`.
+    /// Find the running, Kakao-signed KakaoTalk process.
     ///
     /// We shell out rather than link `NSRunningApplication`/AppKit bindings
     /// because this is the only place we need a pid lookup and it keeps the
@@ -139,13 +258,33 @@ mod imp {
             .output()
             .context("failed to run pgrep")?;
         let stdout = String::from_utf8_lossy(&output.stdout);
-        stdout
-        .lines()
-        .next()
-        .and_then(|line| line.trim().parse::<i32>().ok())
-        .ok_or_else(|| {
-            anyhow!("KakaoTalk is not running (or `{KAKAOTALK_BUNDLE_ID}` not found) — open it and log in first")
-        })
+        let candidates: Vec<i32> = stdout
+            .lines()
+            .filter_map(|line| line.trim().parse::<i32>().ok())
+            .collect();
+        if candidates.is_empty() {
+            anyhow::bail!(
+                "KakaoTalk is not running (or `{KAKAOTALK_BUNDLE_ID}` not found) — open it and log in first"
+            );
+        }
+
+        let authentic: Vec<i32> = candidates
+            .into_iter()
+            .filter(|pid| process_has_expected_kakao_signature(*pid))
+            .collect();
+        match authentic.as_slice() {
+            [pid] => Ok(*pid),
+            [] => anyhow::bail!(
+                "a process named KakaoTalk is running, but its bundle signing identity is not {KAKAOTALK_BUNDLE_ID}/{KAKAOTALK_TEAM_ID}; refusing AX access"
+            ),
+            _ => anyhow::bail!(
+                "multiple authentic KakaoTalk processes are running; refusing to choose an AX target"
+            ),
+        }
+    }
+
+    fn process_has_expected_kakao_signature(pid: i32) -> bool {
+        openkakao_cli::human_auth::validate_kakaotalk_process(pid).is_ok()
     }
 
     /// Check the calling process has been granted Accessibility permission
@@ -166,6 +305,15 @@ mod imp {
         }
     }
 
+    fn bounded_application(pid: i32) -> Result<AXUIElement> {
+        let app = AXUIElement::application(pid);
+        app.set_messaging_timeout(AX_MESSAGE_TIMEOUT_SECS)
+            .map_err(|error| {
+                anyhow!("could not set a bounded KakaoTalk AX messaging timeout: {error:?}")
+            })?;
+        Ok(app)
+    }
+
     fn role(el: &AXUIElement) -> String {
         el.role().map(|s| s.to_string()).unwrap_or_default()
     }
@@ -178,6 +326,38 @@ mod imp {
             .ok()
             .and_then(|v| v.downcast::<CFString>())
             .map(|s| s.to_string())
+    }
+
+    fn attr_as_bool(el: &AXUIElement, name: &str) -> Option<bool> {
+        let attr: AXAttribute<CFType> = AXAttribute::new(&CFString::new(name));
+        el.attribute(&attr)
+            .ok()
+            .and_then(|value| value.downcast::<CFBoolean>())
+            .map(bool::from)
+    }
+
+    fn focus_and_verify(element: &AXUIElement, label: &str) -> Result<()> {
+        let focused_attr: AXAttribute<CFType> = AXAttribute::new(&CFString::new("AXFocused"));
+        if !element
+            .is_settable(&focused_attr)
+            .map_err(|error| anyhow!("could not inspect {label} focus support: {error:?}"))?
+        {
+            anyhow::bail!("{label} is not AX-focusable; refusing synthetic key delivery");
+        }
+        element
+            .set_attribute(&focused_attr, CFBoolean::true_value().as_CFType())
+            .map_err(|error| anyhow!("could not focus {label}: {error:?}"))?;
+
+        let deadline = Instant::now() + COMPOSER_VERIFY_TIMEOUT;
+        loop {
+            if attr_as_bool(element, "AXFocused") == Some(true) {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                anyhow::bail!("could not verify focus on {label}; refusing synthetic key delivery");
+            }
+            sleep(COMPOSER_VERIFY_POLL_INTERVAL);
+        }
     }
 
     /// Find KakaoTalk's main chat-list window, as opposed to any individual
@@ -241,7 +421,16 @@ mod imp {
         value: Option<String>,
         help: Option<String>,
         description: Option<String>,
+        position_x: Option<f64>,
+        width: Option<f64>,
         children: Vec<AxNode>,
+    }
+
+    struct SnapshotBudget {
+        started_at: Instant,
+        nodes: usize,
+        visited: HashSet<usize>,
+        exhausted: bool,
     }
 
     /// Build an `AxNode` tree rooted at `root` with one recursive walk,
@@ -255,7 +444,53 @@ mod imp {
     /// placeholders in the same call (`options = 0`, i.e. don't stop on the
     /// first missing one), so they cost no extra round-trip and simply fail
     /// the `downcast` to `None`.
-    fn snapshot(root: &AXUIElement) -> AxNode {
+    fn snapshot(root: &AXUIElement) -> Result<AxNode> {
+        let mut budget = SnapshotBudget {
+            started_at: Instant::now(),
+            nodes: 0,
+            visited: HashSet::new(),
+            exhausted: false,
+        };
+        let node = snapshot_bounded(root, 0, &mut budget);
+        if budget.exhausted {
+            anyhow::bail!(
+                "KakaoTalk AX snapshot exceeded its depth/node/time safety budget; refusing incomplete UI data"
+            );
+        }
+        Ok(node)
+    }
+
+    fn snapshot_bounded(root: &AXUIElement, depth: usize, budget: &mut SnapshotBudget) -> AxNode {
+        let identity = root.as_concrete_TypeRef() as usize;
+        if !budget.visited.insert(identity) {
+            return AxNode {
+                element: root.clone(),
+                role: String::new(),
+                value: None,
+                help: None,
+                description: None,
+                position_x: None,
+                width: None,
+                children: Vec::new(),
+            };
+        }
+        if depth > SNAPSHOT_MAX_DEPTH
+            || budget.nodes >= SNAPSHOT_MAX_NODES
+            || budget.started_at.elapsed() >= SNAPSHOT_MAX_DURATION
+        {
+            budget.exhausted = true;
+            return AxNode {
+                element: root.clone(),
+                role: String::new(),
+                value: None,
+                help: None,
+                description: None,
+                position_x: None,
+                width: None,
+                children: Vec::new(),
+            };
+        }
+        budget.nodes += 1;
         // Order matters: these indices are read back positionally below.
         let names = CFArray::from_CFTypes(&[
             CFString::new("AXRole").as_CFType(),
@@ -263,6 +498,8 @@ mod imp {
             CFString::new("AXValue").as_CFType(),
             CFString::new("AXHelp").as_CFType(),
             CFString::new("AXDescription").as_CFType(),
+            CFString::new("AXPosition").as_CFType(),
+            CFString::new("AXSize").as_CFType(),
         ]);
 
         let mut values_ref: CFArrayRef = std::ptr::null();
@@ -274,6 +511,9 @@ mod imp {
                 &mut values_ref,
             )
         };
+        if budget.started_at.elapsed() >= SNAPSHOT_MAX_DURATION {
+            budget.exhausted = true;
+        }
         if err != 0 || values_ref.is_null() {
             // Rare: the batch call failed for this element. Fall back to a
             // leaf node carrying just the role via the slow per-attr path,
@@ -284,6 +524,8 @@ mod imp {
                 value: None,
                 help: None,
                 description: None,
+                position_x: None,
+                width: None,
                 children: Vec::new(),
             };
         }
@@ -296,6 +538,43 @@ mod imp {
                 .map(|s| s.to_string())
         };
 
+        let point_at = |i: isize| -> Option<CGPoint> {
+            let value = values.get(i)?;
+            if value.type_of() != unsafe { AXValueGetTypeID() } {
+                return None;
+            }
+            let mut point = CGPoint::new(0.0, 0.0);
+            if unsafe {
+                AXValueGetValue(
+                    value.as_CFTypeRef() as AXValueRef,
+                    kAXValueTypeCGPoint,
+                    (&mut point as *mut CGPoint).cast(),
+                )
+            } {
+                Some(point)
+            } else {
+                None
+            }
+        };
+        let size_at = |i: isize| -> Option<CGSize> {
+            let value = values.get(i)?;
+            if value.type_of() != unsafe { AXValueGetTypeID() } {
+                return None;
+            }
+            let mut size = CGSize::new(0.0, 0.0);
+            if unsafe {
+                AXValueGetValue(
+                    value.as_CFTypeRef() as AXValueRef,
+                    kAXValueTypeCGSize,
+                    (&mut size as *mut CGSize).cast(),
+                )
+            } {
+                Some(size)
+            } else {
+                None
+            }
+        };
+
         // Slot 1 is the AXChildren array. `ConcreteCFType` is only implemented
         // for the untyped `CFArray<*const c_void>`, so downcast to that and
         // wrap each raw element ref as an `AXUIElement` under the get rule
@@ -306,14 +585,16 @@ mod imp {
             .get(1)
             .and_then(|v| v.downcast::<CFArray<*const std::ffi::c_void>>())
             .map(|arr| {
-                arr.iter()
-                    .map(|child_ref| {
-                        let child = unsafe {
-                            AXUIElement::wrap_under_get_rule(*child_ref as AXUIElementRef)
-                        };
-                        snapshot(&child)
-                    })
-                    .collect()
+                let mut children = Vec::new();
+                for child_ref in arr.iter() {
+                    if budget.exhausted {
+                        break;
+                    }
+                    let child =
+                        unsafe { AXUIElement::wrap_under_get_rule(*child_ref as AXUIElementRef) };
+                    children.push(snapshot_bounded(&child, depth + 1, budget));
+                }
+                children
             })
             .unwrap_or_default();
 
@@ -323,6 +604,8 @@ mod imp {
             value: string_at(2),
             help: string_at(3),
             description: string_at(4),
+            position_x: point_at(5).map(|point| point.x),
+            width: size_at(6).map(|size| size.width),
             children: node_children,
         }
     }
@@ -372,23 +655,6 @@ mod imp {
         Ok(())
     }
 
-    /// Type `text` into the focused field by posting one keyboard CGEvent pair
-    /// per character directly to KakaoTalk's pid, using the Unicode string
-    /// payload (`CGEventKeyboardSetUnicodeString`) so Hangul input works without
-    /// needing per-character keycode mapping.
-    fn type_text_to_pid(pid: i32, text: &str) -> Result<()> {
-        let source = CGEventSource::new(CGEventSourceStateID::CombinedSessionState)
-            .map_err(|_| anyhow!("failed to create CGEventSource"))?;
-        for down in [true, false] {
-            let event = CGEvent::new_keyboard_event(source.clone(), 0, down)
-                .map_err(|_| anyhow!("failed to create keyboard CGEvent"))?;
-            let utf16: Vec<u16> = text.encode_utf16().collect();
-            event.set_string_from_utf16_unchecked(&utf16);
-            event.post_to_pid(pid);
-        }
-        Ok(())
-    }
-
     /// Switch the main window to the chat-list ("chatrooms") tab if it isn't
     /// already there — the chat-list `AXTable` only exists while that tab is
     /// active; the Friends tab renders an `AXOutline` instead. Left over from an
@@ -401,10 +667,10 @@ mod imp {
     /// instead of re-taking it in the caller avoids a second full tree walk
     /// in the common case (already on the right tab), which previously
     /// doubled open_chat_row's cost.
-    fn ensure_chatrooms_tab(main_window: &AXUIElement) -> AxNode {
-        let snap = snapshot(main_window);
+    fn ensure_chatrooms_tab(main_window: &AXUIElement) -> Result<AxNode> {
+        let snap = snapshot(main_window)?;
         if snap.find_first("AXTable").is_some() {
-            return snap;
+            return Ok(snap);
         }
         let mut buttons = Vec::new();
         snap.find_all("AXButton", &mut buttons);
@@ -416,7 +682,7 @@ mod imp {
             sleep(Duration::from_millis(400));
             return snapshot(main_window);
         }
-        snap
+        Ok(snap)
     }
 
     fn open_chat_row(app: &AXUIElement, chat_display_name: &str) -> Result<()> {
@@ -424,7 +690,7 @@ mod imp {
         let start = Instant::now();
 
         let main_window = find_main_window(app)?;
-        let snap = ensure_chatrooms_tab(&main_window);
+        let snap = ensure_chatrooms_tab(&main_window)?;
         if debug {
             eprintln!(
                 "[ax_send] open_chat_row: snapshot took {:?}",
@@ -477,6 +743,63 @@ mod imp {
             .element
             .set_attribute(&selected_rows_attr, one_row.as_CFType())
             .map_err(|e| anyhow!("failed to select chat row: {e:?}"))?;
+        focus_and_verify(&table.element, "selected chat-list table")?;
+        let selected_rows = table
+            .element
+            .attribute(&selected_rows_attr)
+            .map_err(|error| anyhow!("failed to verify selected chat row: {error:?}"))?
+            .downcast::<CFArray<*const std::ffi::c_void>>()
+            .ok_or_else(|| anyhow!("selected chat row could not be read back"))?;
+        let selected_exactly_once = selected_rows.len() == 1
+            && selected_rows.get(0).is_some_and(|selected| unsafe {
+                CFEqual(*selected, row.element.as_CFTypeRef()) != 0
+            });
+        if !selected_exactly_once {
+            anyhow::bail!(
+                "selected chat row did not match the exact requested row; refusing Return"
+            );
+        }
+
+        // Open the exact selected row with an element-scoped AX action. A
+        // process-wide synthetic Return here could land in a composer if focus
+        // changed, so keyboard events are reserved for the post-authenticated
+        // final send commit only.
+        let press = CFString::new(kAXPressAction);
+        let confirm = CFString::new("AXConfirm");
+        let row_actions = row
+            .element
+            .action_names()
+            .unwrap_or_else(|_| CFArray::from_CFTypes(&[]));
+        let table_actions = table
+            .element
+            .action_names()
+            .unwrap_or_else(|_| CFArray::from_CFTypes(&[]));
+        let row_supports_press = row_actions
+            .iter()
+            .any(|action| action.to_string() == "AXPress");
+        let row_supports_confirm = row_actions
+            .iter()
+            .any(|action| action.to_string() == "AXConfirm");
+        let table_supports_confirm = table_actions
+            .iter()
+            .any(|action| action.to_string() == "AXConfirm");
+        if row_supports_press {
+            row.element.perform_action(&press).map_err(|error| {
+                anyhow!("failed to open exact chat row with AXPress: {error:?}")
+            })?;
+        } else if row_supports_confirm {
+            row.element.perform_action(&confirm).map_err(|error| {
+                anyhow!("failed to open exact chat row with AXConfirm: {error:?}")
+            })?;
+        } else if table_supports_confirm {
+            table.element.perform_action(&confirm).map_err(|error| {
+                anyhow!("failed to confirm the exact selected chat row: {error:?}")
+            })?;
+        } else {
+            anyhow::bail!(
+                "the exact selected KakaoTalk chat row exposes no safe element-scoped open action; refusing a process-wide Return"
+            );
+        }
 
         if debug {
             eprintln!("[ax_send] open_chat_row: total {:?}", start.elapsed());
@@ -487,8 +810,7 @@ mod imp {
     /// Search a single root (a window, or the whole app as a fallback) for the
     /// message composer: an `AXScrollArea` that wraps an `AXTextArea` but no
     /// `AXTable` (which would make it the message list instead).
-    fn find_input_field_in(root: &AXUIElement) -> Option<AXUIElement> {
-        let snap = snapshot(root);
+    fn find_input_field(snap: &AxNode) -> Option<AXUIElement> {
         let mut scroll_areas = Vec::new();
         snap.find_all("AXScrollArea", &mut scroll_areas);
 
@@ -503,25 +825,26 @@ mod imp {
         None
     }
 
-    /// Find the composer field, preferring the chat window whose title matches
-    /// `chat_display_name` (relevant when more than one chat window is already
-    /// open) and falling back to a whole-app search otherwise.
-    fn find_input_field(app: &AXUIElement, chat_display_name: &str) -> Result<AXUIElement> {
-        if let Ok(windows) = app.windows() {
-            if let Some(window) = windows.iter().find(|w| {
-                w.title()
-                    .map(|t| t.to_string())
-                    .ok()
-                    .is_some_and(|t| t.contains(chat_display_name))
-            }) {
-                if let Some(field) = find_input_field_in(&window) {
-                    return Ok(field);
-                }
-            }
-        }
-        find_input_field_in(app).ok_or_else(|| {
-            anyhow!("could not find the message input field — is the chat window open and focused?")
-        })
+    struct ChatWindowElements {
+        input_field: AXUIElement,
+        message_table: AXUIElement,
+    }
+
+    /// Resolve the composer and message table from one window snapshot so the
+    /// send path does not recursively walk the same AX tree twice before the
+    /// commit point.
+    fn inspect_chat_window(root: &AXUIElement) -> Result<Option<ChatWindowElements>> {
+        let snap = snapshot(root)?;
+        let Some(input_field) = find_input_field(&snap) else {
+            return Ok(None);
+        };
+        let Some(message_table) = snap.find_first("AXTable") else {
+            return Ok(None);
+        };
+        Ok(Some(ChatWindowElements {
+            input_field,
+            message_table: message_table.element.clone(),
+        }))
     }
 
     /// One message bubble scraped from a chat window's AX message list.
@@ -531,6 +854,7 @@ mod imp {
         /// present, else its plain displayed value (e.g. "14:32").
         pub time: Option<String>,
         pub text: String,
+        pub outgoing: bool,
     }
 
     /// Scrape every message bubble currently rendered in a chat window's
@@ -540,23 +864,45 @@ mod imp {
     /// share-labeled `AXButton` ("공유") becomes "[파일]". Rows matching none
     /// of these (date separators, system notices) are skipped, same as
     /// before.
-    fn read_visible_messages(window: &AXUIElement) -> Vec<AxMessage> {
-        let snap = snapshot(window);
+    fn read_visible_messages(window: &AXUIElement) -> Result<Vec<AxMessage>> {
+        let snap = snapshot(window)?;
         let Some(table) = snap.find_first("AXTable") else {
-            return Vec::new();
+            return Ok(Vec::new());
         };
+        Ok(read_visible_messages_from_node(table))
+    }
+
+    fn read_visible_messages_from_table(table: &AXUIElement) -> Result<Vec<AxMessage>> {
+        let snap = snapshot(table)?;
+        Ok(read_visible_messages_from_node(&snap))
+    }
+
+    fn read_visible_messages_from_node(table: &AxNode) -> Vec<AxMessage> {
+        let table_center_x = table
+            .position_x
+            .zip(table.width)
+            .map(|(position_x, width)| position_x + width / 2.0);
         let mut rows = Vec::new();
         table.find_all("AXRow", &mut rows);
 
         rows.iter()
             .filter_map(|row| {
-                let text = message_row_text(row)?;
+                let (text, bubble) = message_row_text(row)?;
+                let outgoing = table_center_x
+                    .zip(bubble.position_x.zip(bubble.width))
+                    .is_some_and(|(table_center, (position_x, width))| {
+                        position_x + width / 2.0 > table_center
+                    });
 
                 let time = row
                     .find_first("AXStaticText")
                     .and_then(|t| t.help.clone().or_else(|| t.value.clone()));
 
-                Some(AxMessage { time, text })
+                Some(AxMessage {
+                    time,
+                    text,
+                    outgoing,
+                })
             })
             .collect()
     }
@@ -564,42 +910,65 @@ mod imp {
     /// Classify one message row into displayable text: the row's own
     /// `AXTextArea` value if present, else a placeholder if the row looks
     /// like an image or file share, else `None` (not a real message row).
-    fn message_row_text(row: &AxNode) -> Option<String> {
+    fn message_row_text(row: &AxNode) -> Option<(String, &AxNode)> {
         if let Some(text_area) = row.find_first("AXTextArea") {
             if let Some(text) = &text_area.value {
-                return Some(text.clone());
+                return Some((text.clone(), text_area));
             }
         }
 
-        if row.find_first("AXImage").is_some() {
-            return Some("[사진]".to_string());
+        if let Some(image) = row.find_first("AXImage") {
+            return Some(("[사진]".to_string(), image));
         }
 
         let mut buttons = Vec::new();
         row.find_all("AXButton", &mut buttons);
-        if buttons
-            .iter()
-            .any(|b| b.description.as_deref() == Some("공유"))
+        if let Some(button) = buttons
+            .into_iter()
+            .find(|button| button.description.as_deref() == Some("공유"))
         {
-            return Some("[파일]".to_string());
+            return Some(("[파일]".to_string(), button));
         }
 
         None
     }
 
-    /// Find an already-open chat window whose title matches `chat_display_name`
-    /// (the other party's — or your own, for the self/memo chat — display name).
-    fn find_chat_window(app: &AXUIElement, chat_display_name: &str) -> Option<AXUIElement> {
-        app.windows()
-            .ok()?
+    /// Find exactly one already-open chat window by its full title. A substring
+    /// match is unsafe here: an allowed target named `Alice` must never reuse an
+    /// unrelated `Alice & Bob` window, and duplicate exact titles are ambiguous.
+    fn find_chat_window(app: &AXUIElement, chat_display_name: &str) -> Result<Option<AXUIElement>> {
+        let windows = app
+            .windows()
+            .map_err(|error| anyhow!("AXWindows read failed: {error:?}"))?;
+        let titles: Vec<Option<String>> = windows
             .iter()
-            .find(|w| {
-                w.title()
-                    .map(|t| t.to_string())
-                    .ok()
-                    .is_some_and(|t| t.contains(chat_display_name))
-            })
-            .map(|w| w.clone())
+            .map(|window| window.title().map(|title| title.to_string()).ok())
+            .collect();
+
+        match super::match_chat_row(&titles, chat_display_name) {
+            super::ChatMatch::NotFound => Ok(None),
+            super::ChatMatch::Found(index) => windows
+                .get(index as isize)
+                .map(|window| (*window).clone())
+                .map(Some)
+                .ok_or_else(|| anyhow!("matched chat window disappeared during AX lookup")),
+            super::ChatMatch::Ambiguous(count) => Err(anyhow!(
+                "chat name '{chat_display_name}' matches {count} open windows exactly — ambiguous, refusing to guess"
+            )),
+        }
+    }
+
+    fn wait_for_composer_value(field: &AXUIElement, expected: &str) -> bool {
+        let deadline = Instant::now() + COMPOSER_VERIFY_TIMEOUT;
+        loop {
+            if attr_as_string(field, "AXValue").as_deref() == Some(expected) {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            sleep(COMPOSER_VERIFY_POLL_INTERVAL);
+        }
     }
 
     /// Read the most recent `count` messages visible in a chat's AX message list,
@@ -613,15 +982,14 @@ mod imp {
         let start = Instant::now();
         let pid = find_kakaotalk_pid()?;
         ensure_ax_permission()?;
-        let app = AXUIElement::application(pid);
+        let app = bounded_application(pid)?;
 
         open_chat_row(&app, chat_display_name)?;
-        press_return(pid)?;
 
         let deadline = Instant::now() + OPEN_CHAT_TIMEOUT;
         let mut messages = loop {
-            if let Some(window) = find_chat_window(&app, chat_display_name) {
-                let msgs = read_visible_messages(&window);
+            if let Some(window) = find_chat_window(&app, chat_display_name)? {
+                let msgs = read_visible_messages(&window)?;
                 if !msgs.is_empty() {
                     break msgs;
                 }
@@ -640,68 +1008,151 @@ mod imp {
         Ok(messages)
     }
 
-    /// Send `message` to the chat identified by `chat_display_name` via AX
-    /// automation. Returns after KakaoTalk accepts the Return key event; callers
-    /// must treat delivery as unconfirmed and avoid automatic retries.
-    ///
-    /// `chat_display_name` should be a substring of the chat's title as shown
-    /// in the chat list (same matching convention as kakaocli's `send`).
-    pub fn send_via_ax(chat_display_name: &str, message: &str) -> Result<()> {
+    /// Send to exactly one chat and classify the result by commit point.
+    /// Errors returned from this function happened before the final Return key,
+    /// while `Uncertain` means Return may have been delivered but a new message
+    /// bubble could not be proven.
+    pub fn send_via_ax_classified(
+        chat_display_name: &str,
+        message: &str,
+    ) -> Result<super::AxDeliveryOutcome> {
         let pid = find_kakaotalk_pid()?;
         ensure_ax_permission()?;
-        let app = AXUIElement::application(pid);
+        let app = bounded_application(pid)?;
 
-        // Fast path for an already-open chat. Avoiding a full snapshot of the
-        // main chat-list window cuts tens of seconds on large chat histories
-        // and does not change the selected/folded state of that window.
-        let field = find_chat_window(&app, chat_display_name)
-            .and_then(|window| find_input_field_in(&window));
+        // Always resolve the target through the chat list, even when an exact-
+        // title window is already open. Otherwise one of two same-named rooms
+        // could bypass the list-level ambiguity check through the old fast path.
+        open_chat_row(&app, chat_display_name)?;
 
-        let field = if let Some(field) = field {
-            field
-        } else {
-            open_chat_row(&app, chat_display_name)?;
-            press_return(pid)?;
-
-            let deadline = Instant::now() + OPEN_CHAT_TIMEOUT;
-            loop {
-                match find_input_field(&app, chat_display_name) {
-                    Ok(field) => break field,
-                    Err(e) => {
-                        if Instant::now() >= deadline {
-                            return Err(e.context("chat window did not open in time"));
-                        }
-                        sleep(Duration::from_millis(150));
-                    }
-                }
-            }
-        };
-
-        if field.set_value(CFString::new(message).as_CFType()).is_err() {
-            type_text_to_pid(pid, message)?;
-        }
-        press_return(pid)?;
-
-        // Scoped verify: poll only the target chat window's own message bubbles
-        // for the sent text — cheap (one window), unlike the old app-wide scan
-        // that could block for tens of seconds. Keeps the fast path fast while
-        // still confirming delivery instead of assuming it.
-        let deadline = Instant::now() + VERIFY_TIMEOUT;
-        loop {
-            if let Some(window) = find_chat_window(&app, chat_display_name) {
-                if read_visible_messages(&window)
-                    .iter()
-                    .any(|m| m.text == message)
-                {
-                    return Ok(());
+        let deadline = Instant::now() + OPEN_CHAT_TIMEOUT;
+        let elements = loop {
+            if let Some(window) = find_chat_window(&app, chat_display_name)? {
+                if let Some(elements) = inspect_chat_window(&window)? {
+                    break elements;
                 }
             }
             if Instant::now() >= deadline {
-                return Err(anyhow!(
-                    "sent the message but could not confirm it appeared in the '{chat_display_name}' \
-                     chat window within {}s — check KakaoTalk before retrying to avoid duplicates",
-                    VERIFY_TIMEOUT.as_secs()
-                ));
+                anyhow::bail!(
+                    "exact chat window '{chat_display_name}' did not open with a readable composer in time"
+                );
+            }
+            sleep(Duration::from_millis(150));
+        };
+
+        let field = elements.input_field;
+        let message_table = elements.message_table;
+
+        let existing_draft = attr_as_string(&field, "AXValue").ok_or_else(|| {
+            anyhow!(
+                "could not read the exact target's composer before commit; refusing to type blindly"
+            )
+        })?;
+        if !existing_draft.is_empty() {
+            anyhow::bail!(
+                "the exact target's composer already contains a draft; refusing to overwrite or append to it"
+            );
+        }
+
+        let baseline: Vec<super::DeliveryObservation> =
+            read_visible_messages_from_table(&message_table)?
+                .into_iter()
+                .map(|message| super::DeliveryObservation {
+                    text: message.text,
+                    outgoing: message.outgoing,
+                })
+                .collect();
+
+        // Keep the OS-mediated human-presence boundary inside the one native
+        // transport implementation. This makes it impossible for a future
+        // command caller to reach a real AX send merely by forgetting its own
+        // prompt. At this point the signed process, unique target row, exact
+        // window, empty composer, and pre-send bubble baseline are all known;
+        // authentication happens immediately before the composer is changed.
+        let authenticated_target =
+            crate::util::escape_terminal_text(&crate::util::truncate(chat_display_name, 80));
+        openkakao_cli::human_auth::require_device_owner_auth(&format!(
+            "Approve one KakaoTalk message to ‘{authenticated_target}’ after reviewing the terminal preview"
+        ))?;
+
+        focus_and_verify(&field, "exact target composer")?;
+        field
+            .set_value(CFString::new(message).as_CFType())
+            .map_err(|error| anyhow!("could not set the exact target composer: {error:?}"))?;
+        if !wait_for_composer_value(&field, message) {
+            anyhow::bail!(
+                "could not verify the exact message in the target composer; Return was not pressed"
+            );
+        }
+
+        // Re-establish and verify focus immediately before the irreversible
+        // PID-scoped Return event. The composer read-back loop above may wait
+        // for up to a second, during which another KakaoTalk control could
+        // otherwise gain focus.
+        focus_and_verify(&field, "exact target composer immediately before commit")?;
+        if attr_as_string(&field, "AXValue").as_deref() != Some(message) {
+            anyhow::bail!(
+                "the exact target composer changed before commit; Return was not pressed"
+            );
+        }
+
+        if let Err(error) = press_return(pid) {
+            return Ok(super::AxDeliveryOutcome::Uncertain {
+                reason: format!(
+                    "Return delivery failed after commit began: {error:#}; inspect KakaoTalk before retrying"
+                ),
+            });
+        }
+
+        // Scoped verify: require an additional exact-text bubble compared with
+        // the pre-commit snapshot. Merely finding old identical text is not
+        // proof that this send produced a new message.
+        let deadline = Instant::now() + VERIFY_TIMEOUT;
+        loop {
+            match find_chat_window(&app, chat_display_name) {
+                Ok(Some(_current_window)) => {
+                    let current: Vec<super::DeliveryObservation> =
+                        match read_visible_messages_from_table(&message_table) {
+                            Ok(messages) => messages
+                                .into_iter()
+                                .map(|message| super::DeliveryObservation {
+                                    text: message.text,
+                                    outgoing: message.outgoing,
+                                })
+                                .collect(),
+                            Err(error) => {
+                                return Ok(super::AxDeliveryOutcome::Uncertain {
+                                    reason: format!(
+                                    "sent the message but bounded AX verification failed: {error:#}"
+                                ),
+                                });
+                            }
+                        };
+                    if super::is_verified_delivery(
+                        &baseline,
+                        &current,
+                        message,
+                        attr_as_string(&field, "AXValue").as_deref(),
+                    ) {
+                        return Ok(super::AxDeliveryOutcome::Verified);
+                    }
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    return Ok(super::AxDeliveryOutcome::Uncertain {
+                        reason: format!(
+                            "sent the message but target-window verification became ambiguous: {error:#}"
+                        ),
+                    });
+                }
+            }
+            if Instant::now() >= deadline {
+                return Ok(super::AxDeliveryOutcome::Uncertain {
+                    reason: format!(
+                        "sent the message but no additional exact-text bubble appeared in the '{chat_display_name}' chat window within {}s — check KakaoTalk before retrying to avoid duplicates",
+                        VERIFY_TIMEOUT.as_secs()
+                    ),
+                });
             }
             sleep(VERIFY_POLL_INTERVAL);
         }
@@ -729,9 +1180,9 @@ mod imp {
     pub fn scrape_chat_list() -> Result<Vec<ChatListRow>> {
         let pid = find_kakaotalk_pid()?;
         ensure_ax_permission()?;
-        let app = AXUIElement::application(pid);
+        let app = bounded_application(pid)?;
         let main_window = find_main_window(&app)?;
-        let snap = ensure_chatrooms_tab(&main_window);
+        let snap = ensure_chatrooms_tab(&main_window)?;
         let table = snap
             .find_first("AXTable")
             .ok_or_else(|| anyhow!("could not find chat list table in KakaoTalk's AX tree"))?;
@@ -805,7 +1256,7 @@ mod imp {
 } // mod imp
 
 #[cfg(target_os = "macos")]
-pub use imp::{read_via_ax, scrape_chat_list, send_via_ax, ChatListRow};
+pub use imp::{read_via_ax, scrape_chat_list, send_via_ax_classified, ChatListRow};
 
 #[cfg(not(target_os = "macos"))]
 mod stub {
@@ -819,9 +1270,13 @@ mod stub {
     pub struct AxMessage {
         pub time: Option<String>,
         pub text: String,
+        pub outgoing: bool,
     }
 
-    pub fn send_via_ax(_chat_display_name: &str, _message: &str) -> Result<()> {
+    pub fn send_via_ax_classified(
+        _chat_display_name: &str,
+        _message: &str,
+    ) -> Result<super::AxDeliveryOutcome> {
         Err(anyhow!(
             "local-send (AX automation) is only supported on macOS"
         ))
@@ -852,4 +1307,11 @@ mod stub {
 }
 
 #[cfg(not(target_os = "macos"))]
-pub use stub::{read_via_ax, scrape_chat_list, send_via_ax, ChatListRow};
+pub use stub::{read_via_ax, scrape_chat_list, send_via_ax_classified, ChatListRow};
+
+pub fn send_via_ax(chat_display_name: &str, message: &str) -> anyhow::Result<()> {
+    match send_via_ax_classified(chat_display_name, message)? {
+        AxDeliveryOutcome::Verified => Ok(()),
+        AxDeliveryOutcome::Uncertain { reason } => Err(anyhow::anyhow!(reason)),
+    }
+}

--- a/src/commands/ax_watch.rs
+++ b/src/commands/ax_watch.rs
@@ -12,8 +12,8 @@ use anyhow::Result;
 
 use crate::ax_send;
 use crate::commands::watch::{
-    parse_webhook_header, run_watch_command_hook_async, run_watch_webhook, validate_webhook_url,
-    watch_hook_matches, WatchHookConfig, WatchMessageEvent, WebhookFormat,
+    dispatch_event, parse_webhook_header, validate_webhook_url, WatchHookConfig, WatchMessageEvent,
+    WebhookFormat,
 };
 use crate::util::require_permission;
 
@@ -125,41 +125,19 @@ pub fn cmd_ax_watch(options: AxWatchOptions) -> Result<()> {
                         let prev = baseline.get(&row.name).copied();
                         if should_emit(prev, row.unread, first) {
                             let event = build_event(row);
-                            if options.json {
-                                println!("{}", event.as_json());
-                            } else {
-                                eprintln!(
-                                    "[ax-watch] {} (+{} unread): {}",
-                                    event.chat_name, event.unread, event.message
-                                );
-                            }
-                            if has_sinks && watch_hook_matches(&hook_config, &event) {
-                                if hook_config.command.is_some() {
-                                    if let Err(e) =
-                                        run_watch_command_hook_async(&hook_config, &event).await
-                                    {
-                                        eprintln!("[ax-watch] hook failed: {e}");
-                                        if hook_config.fail_fast {
-                                            return Err(e);
-                                        }
-                                    }
-                                }
-                                if hook_config.webhook_url.is_some() {
-                                    let cfg = hook_config.clone();
-                                    let ev = event.clone();
-                                    if let Err(e) = tokio::task::spawn_blocking(move || {
-                                        run_watch_webhook(&cfg, &ev)
-                                    })
-                                    .await
-                                    .unwrap_or_else(|e| Err(anyhow::anyhow!(e)))
-                                    {
-                                        eprintln!("[ax-watch] webhook failed: {e}");
-                                        if hook_config.fail_fast {
-                                            return Err(e);
-                                        }
-                                    }
-                                }
-                            }
+                            let human_line = format!(
+                                "[ax-watch] {} (+{} unread): {}",
+                                event.chat_name, event.unread, event.message
+                            );
+                            dispatch_event(
+                                &event,
+                                &hook_config,
+                                has_sinks,
+                                options.json,
+                                &human_line,
+                                "ax-watch",
+                            )
+                            .await?;
                         }
                         baseline.insert(row.name.clone(), row.unread);
                     }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -446,6 +446,19 @@ pub fn cmd_doctor(json: bool, test_loco: bool, config: &OpenKakaoConfig) -> Resu
         }
     }
 
+    // 7a2. Notification access (notif-watch receive path)
+    let notif = crate::commands::notif_watch::check_access();
+    checks.push(Check {
+        name: "Notification access (notif-watch)".into(),
+        // Warn (not Fail) either way — notif-watch is one optional receive path.
+        status: if notif.db_readable && notif.kakao_registered {
+            CheckStatus::Ok
+        } else {
+            CheckStatus::Warn
+        },
+        detail: notif.detail,
+    });
+
     // 7b. LOCO write safety
     checks.push(Check {
         name: "LOCO write operations".into(),

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -451,7 +451,7 @@ pub fn cmd_doctor(json: bool, test_loco: bool, config: &OpenKakaoConfig) -> Resu
     checks.push(Check {
         name: "Notification access (notif-watch)".into(),
         // Warn (not Fail) either way — notif-watch is one optional receive path.
-        status: if notif.db_readable && notif.kakao_registered {
+        status: if notif.db_readable && notif.kakao_registered && notif.schema_compatible {
             CheckStatus::Ok
         } else {
             CheckStatus::Warn

--- a/src/commands/local_send.rs
+++ b/src/commands/local_send.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 
 use crate::ax_send;
-use crate::util::{confirm, truncate, validate_outbound_message};
+use crate::util::{confirm, escape_terminal_text, truncate, validate_outbound_message};
 
 pub struct LocalSendOptions {
     pub chat_name: String,
@@ -28,8 +28,8 @@ pub fn cmd_local_send(opts: LocalSendOptions) -> Result<()> {
     if dry_run {
         eprintln!(
             "[dry-run] Would AX-send to chat \"{}\": \"{}\"",
-            chat_name,
-            truncate(message, 80)
+            escape_terminal_text(chat_name),
+            escape_terminal_text(&truncate(message, 80))
         );
         if json {
             crate::util::output_json(&serde_json::json!({
@@ -42,12 +42,15 @@ pub fn cmd_local_send(opts: LocalSendOptions) -> Result<()> {
         return Ok(());
     }
 
+    eprintln!("Direct AX send review:");
+    eprintln!("  target:  {}", escape_terminal_text(chat_name));
+    eprintln!(
+        "  message: {}",
+        serde_json::to_string(&escape_terminal_text(message))?
+    );
+
     if !skip_confirm {
-        eprint!(
-            "AX-send to chat \"{}\"? Message: \"{}\"\n[y/N] ",
-            chat_name,
-            truncate(message, 50)
-        );
+        eprint!("Continue to macOS device-owner authentication?\n[y/N] ");
         if !confirm()? {
             println!("Cancelled.");
             return Ok(());

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod doctor;
 pub mod download;
 pub mod local_send;
 pub mod members;
+pub mod notif_watch;
 pub mod probe;
 pub mod profile;
 pub mod read;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -12,5 +12,6 @@ pub mod probe;
 pub mod profile;
 pub mod read;
 pub mod rest;
+pub mod safe_send;
 pub mod send;
 pub mod watch;

--- a/src/commands/notif_watch.rs
+++ b/src/commands/notif_watch.rs
@@ -1,0 +1,420 @@
+//! `notif-watch` — login-free receive detection via the macOS Notification
+//! Center database. Polls `usernoted`'s SQLite (read-only) for KakaoTalk
+//! notifications and emits them through the shared watch sinks. Works with the
+//! KakaoTalk window closed, minimized, or on another Space, and self-sent
+//! messages never appear (a message you send posts no notification). No server
+//! contact (no ban risk), no SQLCipher decryption, no login — a read-only read
+//! of a plaintext local SQLite file.
+//!
+//! Limits (structural — see docs): muted/notifications-off chats and the chat
+//! you are currently focused on post no notification, so they are not seen; the
+//! DB retains only notifications still in Notification Center (a forward-only
+//! live stream, not history).
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use plist::Value;
+use rusqlite::{Connection, OpenFlags};
+
+use crate::commands::watch::{
+    dispatch_event, parse_webhook_header, validate_webhook_url, WatchHookConfig, WatchMessageEvent,
+    WebhookFormat,
+};
+use crate::util::require_permission;
+
+/// Seconds between the CFAbsoluteTime epoch (2001-01-01) and the Unix epoch.
+const CFABSOLUTE_EPOCH_OFFSET: f64 = 978_307_200.0;
+
+/// One KakaoTalk message pulled from a notification payload.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NotifMessage {
+    /// `/req/titl` — chat room / sender display name.
+    pub chat_name: String,
+    /// `/req/body` — message text. Empty for image messages or when the user's
+    /// notification-preview setting hides content.
+    pub body: String,
+    /// `iden` prefix — stable per chat room.
+    pub room_id: i64,
+    /// `iden` suffix — per-message id (dedup / ordering key).
+    pub msg_id: i64,
+    /// `/date` — CFAbsoluteTime (seconds since 2001-01-01).
+    pub ts: f64,
+    /// `/req/atta[0]/pat` — local path of the first attachment, or empty.
+    pub attachment_path: String,
+}
+
+/// Decode one notification payload (binary plist) into a `NotifMessage`.
+///
+/// Returns `None` when the payload lacks a parseable `iden` (`<room>_<msg>`,
+/// both decimal) — that id is the dedup key, so a notification without it can't
+/// be tracked. A missing title/body/attachment is fine (fields default empty).
+pub fn parse_notification(payload: &[u8]) -> Option<NotifMessage> {
+    let root = Value::from_reader(std::io::Cursor::new(payload)).ok()?;
+    let dict = root.as_dictionary()?;
+    let req = dict.get("req").and_then(|v| v.as_dictionary());
+
+    let req_str = |k: &str| -> Option<String> {
+        req.and_then(|d| d.get(k))
+            .and_then(|v| v.as_string())
+            .map(|s| s.to_string())
+    };
+
+    // iden = "<room_id>_<msg_id>", both decimal. Required.
+    let iden = req_str("iden")?;
+    let (room_s, msg_s) = iden.split_once('_')?;
+    let room_id = room_s.parse::<i64>().ok()?;
+    let msg_id = msg_s.parse::<i64>().ok()?;
+
+    let chat_name = req_str("titl").unwrap_or_default();
+    let body = req_str("body").unwrap_or_default();
+
+    let ts = dict.get("date").and_then(value_as_f64).unwrap_or(0.0);
+
+    let attachment_path = req
+        .and_then(|r| r.get("atta"))
+        .and_then(|v| v.as_array())
+        .and_then(|a| a.first())
+        .and_then(|v| v.as_dictionary())
+        .and_then(|d| d.get("pat"))
+        .and_then(|v| v.as_string())
+        .unwrap_or_default()
+        .to_string();
+
+    Some(NotifMessage {
+        chat_name,
+        body,
+        room_id,
+        msg_id,
+        ts,
+        attachment_path,
+    })
+}
+
+/// `date` may be stored as a real, an integer, or a numeric string.
+fn value_as_f64(v: &Value) -> Option<f64> {
+    match v {
+        Value::Real(f) => Some(*f),
+        Value::Integer(i) => i.as_signed().map(|n| n as f64),
+        Value::String(s) => s.parse::<f64>().ok(),
+        _ => None,
+    }
+}
+
+/// CFAbsoluteTime → RFC3339 UTC string, matching the other watch sources'
+/// `received_at` format.
+fn ts_to_rfc3339(cf: f64) -> String {
+    let unix = cf + CFABSOLUTE_EPOCH_OFFSET;
+    chrono::DateTime::<chrono::Utc>::from_timestamp(unix as i64, 0)
+        .unwrap_or_else(chrono::Utc::now)
+        .to_rfc3339()
+}
+
+/// Map a decoded notification to the shared watch event.
+pub fn build_event(m: &NotifMessage) -> WatchMessageEvent {
+    WatchMessageEvent {
+        event_type: "notif_message",
+        received_at: ts_to_rfc3339(m.ts),
+        method: "notif".to_string(),
+        chat_id: m.room_id,
+        chat_name: m.chat_name.clone(),
+        log_id: m.msg_id,
+        author_id: 0,
+        author_nickname: String::new(),
+        // 1 = text, 2 = has attachment (mirrors the LOCO message_type convention
+        // closely enough for hook filtering).
+        message_type: if m.attachment_path.is_empty() { 1 } else { 2 },
+        message: m.body.clone(),
+        attachment: m.attachment_path.clone(),
+        unread: 0,
+    }
+}
+
+/// Decide whether a notification should fire this poll.
+///
+/// The first poll only records a baseline (so a backlog of notifications already
+/// sitting in Notification Center doesn't flood on startup); afterwards each
+/// `msg_id` fires exactly once.
+pub fn should_emit(seen: &HashSet<i64>, msg_id: i64, first: bool) -> bool {
+    !first && !seen.contains(&msg_id)
+}
+
+/// Options for `notif-watch` (mirrors `AxWatchOptions`).
+pub struct NotifWatchOptions {
+    pub interval_secs: u64,
+    pub hook_cmd: Option<String>,
+    pub webhook_url: Option<String>,
+    pub webhook_headers: Vec<String>,
+    pub webhook_signing_secret: Option<String>,
+    pub webhook_format: WebhookFormat,
+    pub hook_chats: Vec<String>,
+    pub hook_keywords: Vec<String>,
+    pub fail_fast: bool,
+    pub allow_insecure_webhooks: bool,
+    pub min_hook_interval_secs: u64,
+    pub min_webhook_interval_secs: u64,
+    pub hook_timeout_secs: u64,
+    pub webhook_timeout_secs: u64,
+    pub json: bool,
+    pub unattended: bool,
+    pub allow_side_effects: bool,
+}
+
+/// Path to the macOS Notification Center database.
+fn notif_db_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("No home directory")?;
+    Ok(home.join("Library/Group Containers/group.com.apple.usernoted/db2/db"))
+}
+
+/// Read the current KakaoTalk notification payloads, read-only.
+///
+// ponytail: opens immutable (ignores -wal) so a fresh connection each poll never
+// locks the live DB; the only cost is a notification still in the WAL isn't seen
+// until macOS checkpoints it into the main file — fine at watch cadence. Upgrade
+// path if that latency ever matters: copy db+db-wal to a temp file and open that.
+fn read_kakao_payloads(db_path: &Path) -> Result<Vec<Vec<u8>>> {
+    let uri = format!("file:{}?mode=ro&immutable=1", db_path.display());
+    let conn = Connection::open_with_flags(
+        &uri,
+        OpenFlags::SQLITE_OPEN_READ_ONLY
+            | OpenFlags::SQLITE_OPEN_URI
+            | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .with_context(|| format!("open notification DB: {}", db_path.display()))?;
+
+    let mut stmt = conn.prepare(
+        "SELECT r.data FROM record r JOIN app a ON r.app_id = a.app_id \
+         WHERE a.identifier LIKE '%kakao%' AND r.data IS NOT NULL",
+    )?;
+    let rows = stmt.query_map([], |row| row.get::<_, Vec<u8>>(0))?;
+    Ok(rows.filter_map(|r| r.ok()).collect())
+}
+
+/// Poll the Notification Center DB and fire hooks/webhooks on new KakaoTalk
+/// messages. Runs until interrupted (Ctrl-C).
+pub fn cmd_notif_watch(options: NotifWatchOptions) -> Result<()> {
+    if options.hook_cmd.is_some() || options.webhook_url.is_some() {
+        require_permission(
+            options.unattended && options.allow_side_effects,
+            "notif-watch side effects (hooks or webhooks)",
+            "Re-run with --unattended --allow-watch-side-effects, or set both in ~/.config/openkakao/config.toml.",
+        )?;
+    }
+
+    if let Some(url) = &options.webhook_url {
+        validate_webhook_url(url, options.allow_insecure_webhooks)?;
+    }
+    let webhook_headers = options
+        .webhook_headers
+        .iter()
+        .map(|h| parse_webhook_header(h))
+        .collect::<Result<Vec<_>>>()?;
+
+    let hook_config = WatchHookConfig {
+        command: options.hook_cmd.clone(),
+        webhook_url: options.webhook_url.clone(),
+        webhook_headers,
+        webhook_signing_secret: options.webhook_signing_secret.clone(),
+        webhook_format: options.webhook_format,
+        chat_ids: vec![],
+        chat_names: options.hook_chats.clone(),
+        keywords: options.hook_keywords.clone(),
+        message_types: vec![],
+        fail_fast: options.fail_fast,
+        min_hook_interval_secs: options.min_hook_interval_secs,
+        min_webhook_interval_secs: options.min_webhook_interval_secs,
+        hook_timeout_secs: options.hook_timeout_secs,
+        webhook_timeout_secs: options.webhook_timeout_secs,
+    };
+    let has_sinks = hook_config.command.is_some() || hook_config.webhook_url.is_some();
+
+    let db_path = notif_db_path()?;
+
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        // ponytail: unbounded set of seen msg_ids. A long-running watch grows it
+        // slowly; bound to a ring buffer only if memory ever matters.
+        let mut seen: HashSet<i64> = HashSet::new();
+        let mut first = true;
+        eprintln!(
+            "[notif-watch] polling macOS notification center every {}s (Ctrl-C to stop)",
+            options.interval_secs
+        );
+        loop {
+            match read_kakao_payloads(&db_path) {
+                Ok(payloads) => {
+                    for payload in &payloads {
+                        let Some(msg) = parse_notification(payload) else {
+                            continue;
+                        };
+                        if should_emit(&seen, msg.msg_id, first) {
+                            let event = build_event(&msg);
+                            let human_line = format!(
+                                "[notif-watch] {}: {}",
+                                event.chat_name,
+                                if event.message.is_empty() {
+                                    "(attachment)"
+                                } else {
+                                    &event.message
+                                }
+                            );
+                            dispatch_event(
+                                &event,
+                                &hook_config,
+                                has_sinks,
+                                options.json,
+                                &human_line,
+                                "notif-watch",
+                            )
+                            .await?;
+                        }
+                        seen.insert(msg.msg_id);
+                    }
+                    first = false;
+                }
+                Err(e) => {
+                    eprintln!("[notif-watch] read failed (retrying next poll): {e}");
+                }
+            }
+            tokio::time::sleep(Duration::from_secs(options.interval_secs)).await;
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use plist::{Dictionary, Value};
+
+    /// Build a synthetic notification payload matching KakaoTalk's structure,
+    /// so tests carry no real message content.
+    fn make_payload(
+        titl: &str,
+        body: Option<&str>,
+        iden: &str,
+        date: f64,
+        attachment: Option<&str>,
+    ) -> Vec<u8> {
+        let mut req = Dictionary::new();
+        req.insert("titl".into(), Value::String(titl.into()));
+        req.insert("iden".into(), Value::String(iden.into()));
+        if let Some(b) = body {
+            req.insert("body".into(), Value::String(b.into()));
+        }
+        if let Some(p) = attachment {
+            let mut atta = Dictionary::new();
+            atta.insert("pat".into(), Value::String(p.into()));
+            req.insert("atta".into(), Value::Array(vec![Value::Dictionary(atta)]));
+        }
+        let mut root = Dictionary::new();
+        root.insert("app".into(), Value::String("com.kakao.KakaoTalkMac".into()));
+        root.insert("date".into(), Value::Real(date));
+        root.insert("req".into(), Value::Dictionary(req));
+
+        let mut buf = Vec::new();
+        Value::Dictionary(root)
+            .to_writer_binary(&mut buf)
+            .expect("write bplist");
+        buf
+    }
+
+    #[test]
+    fn parses_text_message() {
+        let p = make_payload(
+            "테스트방",
+            Some("안녕하세요"),
+            "474071844489941_3891201215281264642",
+            806497332.35,
+            None,
+        );
+        let m = parse_notification(&p).expect("should parse");
+        assert_eq!(m.chat_name, "테스트방");
+        assert_eq!(m.body, "안녕하세요");
+        assert_eq!(m.room_id, 474071844489941);
+        assert_eq!(m.msg_id, 3891201215281264642);
+        assert_eq!(m.attachment_path, "");
+    }
+
+    #[test]
+    fn parses_image_message_with_empty_body_and_attachment() {
+        let p = make_payload(
+            "테스트방",
+            None,
+            "474071844489941_3891759278451095553",
+            806563858.72,
+            Some("/tmp/photo.jpeg"),
+        );
+        let m = parse_notification(&p).expect("should parse");
+        assert_eq!(m.body, "");
+        assert_eq!(m.attachment_path, "/tmp/photo.jpeg");
+        let ev = build_event(&m);
+        assert_eq!(ev.message, "");
+        assert_eq!(ev.attachment, "/tmp/photo.jpeg");
+        assert_eq!(ev.message_type, 2);
+    }
+
+    #[test]
+    fn same_room_shares_room_id_distinct_msg_id() {
+        let a = parse_notification(&make_payload(
+            "방", Some("첫"), "474071844489941_100", 1.0, None,
+        ))
+        .unwrap();
+        let b = parse_notification(&make_payload(
+            "방", Some("둘"), "474071844489941_200", 2.0, None,
+        ))
+        .unwrap();
+        assert_eq!(a.room_id, b.room_id);
+        assert_ne!(a.msg_id, b.msg_id);
+    }
+
+    #[test]
+    fn rejects_payload_without_parseable_iden() {
+        // no iden at all
+        let no_iden = {
+            let mut req = Dictionary::new();
+            req.insert("titl".into(), Value::String("방".into()));
+            req.insert("body".into(), Value::String("hi".into()));
+            let mut root = Dictionary::new();
+            root.insert("req".into(), Value::Dictionary(req));
+            let mut buf = Vec::new();
+            Value::Dictionary(root).to_writer_binary(&mut buf).unwrap();
+            buf
+        };
+        assert!(parse_notification(&no_iden).is_none());
+        // non-numeric iden
+        let bad = make_payload("방", Some("hi"), "abc_def", 1.0, None);
+        assert!(parse_notification(&bad).is_none());
+    }
+
+    #[test]
+    fn build_event_maps_iden_and_timestamp() {
+        let m = parse_notification(&make_payload(
+            "방", Some("hi"), "42_99", 0.0, None,
+        ))
+        .unwrap();
+        let ev = build_event(&m);
+        assert_eq!(ev.chat_id, 42);
+        assert_eq!(ev.log_id, 99);
+        assert_eq!(ev.method, "notif");
+        assert_eq!(ev.event_type, "notif_message");
+        // date=0 CFAbsoluteTime == 2001-01-01T00:00:00Z
+        assert!(ev.received_at.starts_with("2001-01-01T00:00:00"));
+    }
+
+    #[test]
+    fn should_emit_baselines_first_poll_then_dedups() {
+        let mut seen = HashSet::new();
+        // first poll: never emit, just baseline
+        assert!(!should_emit(&seen, 1, true));
+        seen.insert(1);
+        // later poll: a new id emits
+        assert!(should_emit(&seen, 2, false));
+        seen.insert(2);
+        // already seen: no re-emit
+        assert!(!should_emit(&seen, 2, false));
+        // baselined id: no emit
+        assert!(!should_emit(&seen, 1, false));
+    }
+}

--- a/src/commands/notif_watch.rs
+++ b/src/commands/notif_watch.rs
@@ -18,18 +18,23 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use plist::Value;
 use rusqlite::{Connection, OpenFlags};
+use serde::{Deserialize, Serialize};
 
 use crate::commands::watch::{
-    dispatch_event, parse_webhook_header, validate_webhook_url, WatchHookConfig, WatchMessageEvent,
-    WebhookFormat,
+    dispatch_event, parse_webhook_header, validate_webhook_url, watch_hook_matches, DispatchReport,
+    WatchHookConfig, WatchMessageEvent, WebhookFormat,
 };
-use crate::util::require_permission;
+use crate::receive_inbox::{FailureDisposition, ReceiveInbox};
+use crate::util::{escape_terminal_text, require_permission};
 
 /// Seconds between the CFAbsoluteTime epoch (2001-01-01) and the Unix epoch.
 const CFABSOLUTE_EPOCH_OFFSET: f64 = 978_307_200.0;
+/// KakaoTalk's macOS bundle identifier as stored by Notification Center.
+const KAKAO_BUNDLE_ID: &str = "com.kakao.kakaotalkmac";
+const TERMINAL_LEDGER_GRACE_SECS: u64 = 24 * 60 * 60;
 
 /// One KakaoTalk message pulled from a notification payload.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct NotifMessage {
     /// `/req/titl` — chat room / sender display name.
     pub chat_name: String,
@@ -98,7 +103,10 @@ pub fn parse_notification(payload: &[u8]) -> Option<NotifMessage> {
 fn value_as_f64(v: &Value) -> Option<f64> {
     match v {
         Value::Real(f) => Some(*f),
-        Value::Integer(i) => i.as_signed().map(|n| n as f64),
+        Value::Integer(i) => i
+            .as_signed()
+            .map(|n| n as f64)
+            .or_else(|| i.as_unsigned().map(|n| n as f64)),
         Value::String(s) => s.parse::<f64>().ok(),
         Value::Date(d) => {
             // plist::Date → SystemTime → Unix secs → CFAbsoluteTime
@@ -116,11 +124,12 @@ fn value_as_f64(v: &Value) -> Option<f64> {
 /// `received_at` format. A non-positive/absent timestamp falls back to now()
 /// (the notification just arrived) rather than 2001-01-01.
 fn ts_to_rfc3339(cf: f64) -> String {
-    if cf <= 0.0 {
+    if !cf.is_finite() || cf <= 0.0 {
         return chrono::Utc::now().to_rfc3339();
     }
     let unix = cf + CFABSOLUTE_EPOCH_OFFSET;
-    chrono::DateTime::<chrono::Utc>::from_timestamp(unix as i64, 0)
+    let micros = (unix * 1_000_000.0).round() as i64;
+    chrono::DateTime::<chrono::Utc>::from_timestamp_micros(micros)
         .unwrap_or_else(chrono::Utc::now)
         .to_rfc3339()
 }
@@ -145,19 +154,52 @@ pub fn build_event(m: &NotifMessage) -> WatchMessageEvent {
     }
 }
 
-/// Decide whether a notification should fire this poll.
+/// Tracks one Notification Center snapshot and returns notifications newly
+/// present in the next snapshot. Keeping only the previous snapshot bounds
+/// memory by Notification Center's retention instead of watch-process uptime.
 ///
-/// The first poll only records a baseline (so a backlog of notifications already
-/// sitting in Notification Center doesn't flood on startup); afterwards each
-/// `(room_id, msg_id)` fires exactly once. Keying on the room too (not just the
-/// message id) is safe even if the `iden` suffix turns out to be per-room.
-pub fn should_emit(seen: &HashSet<(i64, i64)>, key: (i64, i64), first: bool) -> bool {
-    !first && !seen.contains(&key)
+/// The first observation establishes a baseline so notifications that predate
+/// startup do not flood the sinks. Duplicate records in one DB snapshot are
+/// emitted at most once.
+#[derive(Default)]
+struct NotificationTracker {
+    previous: HashSet<(i64, i64)>,
+    initialized: bool,
+}
+
+impl NotificationTracker {
+    /// Construct a tracker whose first observation is emitted instead of used
+    /// only as a baseline. This is opt-in because retained notifications may
+    /// predate the current process invocation.
+    fn replay_existing() -> Self {
+        Self {
+            previous: HashSet::new(),
+            initialized: true,
+        }
+    }
+
+    fn observe<'a>(&mut self, messages: &'a [NotifMessage]) -> Vec<&'a NotifMessage> {
+        let mut current = HashSet::with_capacity(messages.len());
+        let mut fresh = Vec::new();
+
+        for message in messages {
+            let key = (message.room_id, message.msg_id);
+            if current.insert(key) && self.initialized && !self.previous.contains(&key) {
+                fresh.push(message);
+            }
+        }
+
+        self.previous = current;
+        self.initialized = true;
+        fresh
+    }
 }
 
 /// Options for `notif-watch` (mirrors `AxWatchOptions`).
 pub struct NotifWatchOptions {
     pub interval_secs: u64,
+    pub replay_existing: bool,
+    pub durable: bool,
     pub hook_cmd: Option<String>,
     pub webhook_url: Option<String>,
     pub webhook_headers: Vec<String>,
@@ -174,6 +216,123 @@ pub struct NotifWatchOptions {
     pub json: bool,
     pub unattended: bool,
     pub allow_side_effects: bool,
+}
+
+struct NotifSink<'a> {
+    hook_config: &'a WatchHookConfig,
+    has_sinks: bool,
+    json: bool,
+}
+
+impl NotifSink<'_> {
+    async fn emit(&self, message: &NotifMessage) -> Result<DispatchReport> {
+        let event = build_event(message);
+        let human_line = format!(
+            "[notif-watch] {}: {}",
+            escape_terminal_text(&event.chat_name),
+            if event.message.is_empty() {
+                "(attachment)".to_string()
+            } else {
+                escape_terminal_text(&event.message)
+            }
+        );
+        dispatch_event(
+            &event,
+            self.hook_config,
+            self.has_sinks,
+            self.json,
+            &human_line,
+            "notif-watch",
+        )
+        .await
+    }
+
+    async fn drain(&self, inbox: &ReceiveInbox) -> Result<()> {
+        let lease_secs = delivery_lease_secs(self.hook_config);
+        for _ in 0..1_000 {
+            let Some(claim) = inbox.claim_next(lease_secs)? else {
+                break;
+            };
+            let pending = &claim.event;
+            let message: NotifMessage = match serde_json::from_value(pending.payload.clone()) {
+                Ok(message) => message,
+                Err(error) => {
+                    let summary = format!("decode durable event {}: {error}", pending.event_id);
+                    inbox.mark_claim_quarantined(&claim, &summary)?;
+                    eprintln!(
+                        "[notif-watch] quarantined malformed durable event {}: {}",
+                        pending.event_id, error
+                    );
+                    continue;
+                }
+            };
+            let report = match self.emit(&message).await {
+                Ok(report) => report,
+                Err(error) => {
+                    let disposition = inbox.mark_failed(&claim, &error.to_string())?;
+                    report_retry_disposition(&pending.event_id, disposition);
+                    return Err(error).with_context(|| {
+                        format!("deliver durable notification event {}", pending.event_id)
+                    });
+                }
+            };
+            if report.is_success() {
+                inbox.mark_delivered(&claim)?;
+                if self.uses_throttled_sink(&message) {
+                    break;
+                }
+            } else {
+                let summary = report.error_summary();
+                let disposition = inbox.mark_failed(&claim, &summary)?;
+                report_retry_disposition(&pending.event_id, disposition);
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    fn uses_throttled_sink(&self, message: &NotifMessage) -> bool {
+        if !watch_hook_matches(self.hook_config, &build_event(message)) {
+            return false;
+        }
+        (self.hook_config.command.is_some() && self.hook_config.min_hook_interval_secs > 0)
+            || (self.hook_config.webhook_url.is_some()
+                && self.hook_config.min_webhook_interval_secs > 0)
+    }
+}
+
+fn delivery_lease_secs(config: &WatchHookConfig) -> u64 {
+    // Hook and webhook delivery are sequential. Lease for their combined
+    // worst-case runtime so a second watcher cannot reclaim a still-live
+    // delivery between sinks.
+    let hook_budget = config
+        .command
+        .as_ref()
+        .map(|_| config.hook_timeout_secs.max(1))
+        .unwrap_or(0);
+    let webhook_budget = config
+        .webhook_url
+        .as_ref()
+        .map(|_| config.webhook_timeout_secs.max(1))
+        .unwrap_or(0);
+    hook_budget
+        .saturating_add(webhook_budget)
+        .saturating_add(60)
+}
+
+fn report_retry_disposition(event_id: &str, disposition: FailureDisposition) {
+    match disposition {
+        FailureDisposition::RetryScheduled { delay_secs } => eprintln!(
+            "[notif-watch] delivery deferred for {event_id}; retrying in about {delay_secs}s"
+        ),
+        FailureDisposition::Quarantined => eprintln!(
+            "[notif-watch] delivery quarantined for {event_id} after repeated failures; later events can continue"
+        ),
+    }
+}
+
+fn notification_event_id(message: &NotifMessage) -> String {
+    format!("notif:{}:{}", message.room_id, message.msg_id)
 }
 
 /// Path to the macOS Notification Center database.
@@ -204,18 +363,78 @@ fn read_kakao_payloads(db_path: &Path) -> Result<Vec<Vec<u8>>> {
     let conn = open_notif_db(db_path)?;
     let mut stmt = conn.prepare(
         "SELECT r.data FROM record r JOIN app a ON r.app_id = a.app_id \
-         WHERE a.identifier LIKE '%kakao%' AND r.data IS NOT NULL",
+         WHERE lower(a.identifier) = ?1 AND r.data IS NOT NULL \
+         ORDER BY COALESCE(r.request_last_date, r.request_date, r.delivered_date, 0), r.rec_id",
     )?;
-    let rows = stmt.query_map([], |row| row.get::<_, Vec<u8>>(0))?;
-    Ok(rows.filter_map(|r| r.ok()).collect())
+    let rows = stmt.query_map([KAKAO_BUNDLE_ID], |row| row.get::<_, Vec<u8>>(0))?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+}
+
+/// One decoded Notification Center snapshot plus per-record diagnostics.
+/// Malformed records must not poison all later notifications, but they also
+/// must not disappear silently because they can signal KakaoTalk schema drift.
+struct NotificationSnapshot {
+    messages: Vec<NotifMessage>,
+    warnings: Vec<String>,
+}
+
+/// Read and decode the current KakaoTalk notification snapshot. Non-message
+/// KakaoTalk notifications intentionally have no `<room>_<message>` identity
+/// and are skipped. Individual malformed records are reported in `warnings`
+/// while structurally invalid SQLite queries still fail the whole read.
+fn read_kakao_notifications(db_path: &Path) -> Result<NotificationSnapshot> {
+    let mut messages = Vec::new();
+    let mut warnings = Vec::new();
+    for (index, payload) in read_kakao_payloads(db_path)?.into_iter().enumerate() {
+        let root = match Value::from_reader(std::io::Cursor::new(&payload)) {
+            Ok(root) => root,
+            Err(error) => {
+                warnings.push(format!(
+                    "KakaoTalk notification payload row {index} is malformed: {error}"
+                ));
+                continue;
+            }
+        };
+        let has_message_identity = root
+            .as_dictionary()
+            .and_then(|dict| dict.get("req"))
+            .and_then(Value::as_dictionary)
+            .is_some_and(|req| req.contains_key("iden"));
+        if !has_message_identity {
+            continue;
+        }
+        match parse_notification(&payload) {
+            Some(message) => messages.push(message),
+            None => warnings.push(format!(
+                "KakaoTalk notification payload row {index} has an identity but no parseable <room>_<message> id; notification schema may have changed"
+            )),
+        }
+    }
+    Ok(NotificationSnapshot { messages, warnings })
+}
+
+fn report_schema_warnings(snapshot: &NotificationSnapshot, previous_summary: &mut Option<String>) {
+    if snapshot.warnings.is_empty() {
+        *previous_summary = None;
+        return;
+    }
+    let summary = format!(
+        "{} malformed KakaoTalk notification record(s); continuing with valid records. First error: {}",
+        snapshot.warnings.len(),
+        snapshot.warnings[0]
+    );
+    if previous_summary.as_deref() != Some(summary.as_str()) {
+        eprintln!("[notif-watch] schema warning: {summary}");
+        *previous_summary = Some(summary);
+    }
 }
 
 /// Whether KakaoTalk is registered as a notifier in an open notification DB.
 /// Split out from [`check_access`] so it can be tested against an in-memory DB.
 fn kakao_notifier_registered(conn: &Connection) -> rusqlite::Result<bool> {
     let count: i64 = conn.query_row(
-        "SELECT count(*) FROM app WHERE identifier LIKE '%kakao%'",
-        [],
+        "SELECT count(*) FROM app WHERE lower(identifier) = ?1",
+        [KAKAO_BUNDLE_ID],
         |row| row.get(0),
     )?;
     Ok(count > 0)
@@ -227,6 +446,8 @@ pub struct NotifAccess {
     pub db_readable: bool,
     /// Whether KakaoTalk is registered as a notifier (needs notifications on).
     pub kakao_registered: bool,
+    /// Whether current Kakao payloads and DB columns match the reader.
+    pub schema_compatible: bool,
     /// Human-readable summary for the doctor row.
     pub detail: String,
 }
@@ -239,6 +460,7 @@ pub fn check_access() -> NotifAccess {
             return NotifAccess {
                 db_readable: false,
                 kakao_registered: false,
+                schema_compatible: false,
                 detail: format!("cannot resolve home directory: {e}"),
             }
         }
@@ -247,16 +469,40 @@ pub fn check_access() -> NotifAccess {
         return NotifAccess {
             db_readable: false,
             kakao_registered: false,
+            schema_compatible: false,
             detail: format!("notification DB not found at {}", path.display()),
         };
     }
     match open_notif_db(&path) {
         Ok(conn) => {
             let kakao = kakao_notifier_registered(&conn).unwrap_or(false);
+            let schema_check = if kakao {
+                read_kakao_notifications(&path)
+            } else {
+                Ok(NotificationSnapshot {
+                    messages: Vec::new(),
+                    warnings: Vec::new(),
+                })
+            };
+            let schema_compatible = schema_check
+                .as_ref()
+                .is_ok_and(|snapshot| snapshot.warnings.is_empty());
             NotifAccess {
                 db_readable: true,
                 kakao_registered: kakao,
-                detail: if kakao {
+                schema_compatible,
+                detail: if let Err(error) = &schema_check {
+                    format!("notification DB is readable, but its KakaoTalk schema is incompatible: {error}")
+                } else if let Some(snapshot) = schema_check
+                    .as_ref()
+                    .ok()
+                    .filter(|snapshot| !snapshot.warnings.is_empty())
+                {
+                    format!(
+                        "notification DB is readable, but {} KakaoTalk payload(s) are malformed; valid records remain readable",
+                        snapshot.warnings.len()
+                    )
+                } else if kakao {
                     "notification DB readable; KakaoTalk registered as notifier".to_string()
                 } else {
                     "notification DB readable, but KakaoTalk is not a registered notifier — \
@@ -268,6 +514,7 @@ pub fn check_access() -> NotifAccess {
         Err(e) => NotifAccess {
             db_readable: false,
             kakao_registered: false,
+            schema_compatible: false,
             detail: format!("cannot open notification DB read-only: {e}"),
         },
     }
@@ -314,54 +561,105 @@ pub fn cmd_notif_watch(options: NotifWatchOptions) -> Result<()> {
     let db_path = notif_db_path()?;
     // A 0s interval would busy-loop and hammer the DB; keep at least 1s.
     let interval_secs = options.interval_secs.max(1);
-
+    let durable_inbox = if options.durable {
+        Some(ReceiveInbox::open()?)
+    } else {
+        None
+    };
+    // Fail once, with context, for permanent startup problems such as a missing
+    // DB, Full Disk Access denial, or an incompatible schema. Once a valid
+    // baseline exists, transient read failures are retried inside the loop.
+    let initial_read = read_kakao_notifications(&db_path);
     let rt = tokio::runtime::Runtime::new()?;
-    rt.block_on(async {
-        // ponytail: unbounded set of seen (room_id, msg_id) keys. A long-running
-        // watch grows it slowly; bound to a ring buffer only if memory matters.
-        let mut seen: HashSet<(i64, i64)> = HashSet::new();
-        let mut first = true;
-        eprintln!(
-            "[notif-watch] polling macOS notification center every {interval_secs}s (Ctrl-C to stop)"
-        );
-        loop {
-            match read_kakao_payloads(&db_path) {
-                Ok(payloads) => {
-                    for payload in &payloads {
-                        let Some(msg) = parse_notification(payload) else {
-                            continue;
-                        };
-                        let key = (msg.room_id, msg.msg_id);
-                        if should_emit(&seen, key, first) {
-                            let event = build_event(&msg);
-                            let human_line = format!(
-                                "[notif-watch] {}: {}",
-                                event.chat_name,
-                                if event.message.is_empty() {
-                                    "(attachment)"
-                                } else {
-                                    &event.message
-                                }
-                            );
-                            dispatch_event(
-                                &event,
-                                &hook_config,
-                                has_sinks,
-                                options.json,
-                                &human_line,
-                                "notif-watch",
-                            )
-                            .await?;
-                        }
-                        seen.insert(key);
+    let mut last_schema_warning = None;
+    let initial_messages = match initial_read {
+        Ok(snapshot) => {
+            report_schema_warnings(&snapshot, &mut last_schema_warning);
+            snapshot.messages
+        }
+        Err(error) => {
+            if let Some(inbox) = durable_inbox.as_ref() {
+                rt.block_on(
+                    NotifSink {
+                        hook_config: &hook_config,
+                        has_sinks,
+                        json: options.json,
                     }
-                    first = false;
+                    .drain(inbox),
+                )?;
+            }
+            return Err(error).context(
+                "notif-watch could not read the macOS Notification Center database; \
+                 grant Full Disk Access to this terminal and run `openkakao-cli doctor --json`",
+            );
+        }
+    };
+    let retained_count = initial_messages.len();
+    let replay_retained = options.replay_existing || options.durable;
+    let mut tracker = if replay_retained {
+        NotificationTracker::replay_existing()
+    } else {
+        NotificationTracker::default()
+    };
+    let mut pending_messages = Some(initial_messages);
+
+    rt.block_on(async {
+        let sink = NotifSink {
+            hook_config: &hook_config,
+            has_sinks,
+            json: options.json,
+        };
+
+        if options.durable {
+            eprintln!(
+                "[notif-watch] durable inbox enabled; reconciling {retained_count} retained \
+                 message(s); polling every {interval_secs}s (Ctrl-C to stop)"
+            );
+        } else if options.replay_existing {
+            eprintln!(
+                "[notif-watch] replaying {retained_count} retained message(s); polling every \
+                 {interval_secs}s (Ctrl-C to stop)"
+            );
+        } else {
+            eprintln!(
+                "[notif-watch] baseline: {retained_count} retained message(s); polling every \
+                 {interval_secs}s (Ctrl-C to stop)"
+            );
+        }
+
+        loop {
+            if let Some(messages) = pending_messages.take() {
+                let retained_event_ids: HashSet<String> =
+                    messages.iter().map(notification_event_id).collect();
+                for message in tracker.observe(&messages) {
+                    if let Some(inbox) = durable_inbox.as_ref() {
+                        let event_id = notification_event_id(message);
+                        inbox.capture(&event_id, "notif", message)?;
+                    } else {
+                        sink.emit(message).await?;
+                    }
                 }
-                Err(e) => {
-                    eprintln!("[notif-watch] read failed (retrying next poll): {e}");
+                if let Some(inbox) = durable_inbox.as_ref() {
+                    inbox.reconcile_terminal(
+                        "notif",
+                        &retained_event_ids,
+                        TERMINAL_LEDGER_GRACE_SECS,
+                    )?;
                 }
             }
+
+            if let Some(inbox) = durable_inbox.as_ref() {
+                sink.drain(inbox).await?;
+            }
+
             tokio::time::sleep(Duration::from_secs(interval_secs)).await;
+            match read_kakao_notifications(&db_path) {
+                Ok(snapshot) => {
+                    report_schema_warnings(&snapshot, &mut last_schema_warning);
+                    pending_messages = Some(snapshot.messages);
+                }
+                Err(e) => eprintln!("[notif-watch] read failed (retrying next poll): {e}"),
+            }
         }
     })
 }
@@ -370,6 +668,36 @@ pub fn cmd_notif_watch(options: NotifWatchOptions) -> Result<()> {
 mod tests {
     use super::*;
     use plist::{Dictionary, Value};
+
+    fn test_hook_config() -> WatchHookConfig {
+        WatchHookConfig {
+            command: None,
+            webhook_url: None,
+            webhook_headers: vec![],
+            webhook_signing_secret: None,
+            webhook_format: WebhookFormat::Raw,
+            chat_ids: vec![],
+            chat_names: vec![],
+            keywords: vec![],
+            message_types: vec![],
+            fail_fast: false,
+            min_hook_interval_secs: 0,
+            min_webhook_interval_secs: 0,
+            hook_timeout_secs: 10,
+            webhook_timeout_secs: 10,
+        }
+    }
+
+    fn test_message(room_id: i64, msg_id: i64) -> NotifMessage {
+        NotifMessage {
+            chat_name: "방".into(),
+            body: format!("message-{msg_id}"),
+            room_id,
+            msg_id,
+            ts: 1.0,
+            attachment_path: String::new(),
+        }
+    }
 
     /// Build a synthetic notification payload matching KakaoTalk's structure,
     /// so tests carry no real message content.
@@ -441,11 +769,19 @@ mod tests {
     #[test]
     fn same_room_shares_room_id_distinct_msg_id() {
         let a = parse_notification(&make_payload(
-            "방", Some("첫"), "474071844489941_100", 1.0, None,
+            "방",
+            Some("첫"),
+            "474071844489941_100",
+            1.0,
+            None,
         ))
         .unwrap();
         let b = parse_notification(&make_payload(
-            "방", Some("둘"), "474071844489941_200", 2.0, None,
+            "방",
+            Some("둘"),
+            "474071844489941_200",
+            2.0,
+            None,
         ))
         .unwrap();
         assert_eq!(a.room_id, b.room_id);
@@ -473,14 +809,14 @@ mod tests {
 
     #[test]
     fn build_event_maps_iden_and_timestamp() {
-        // CFAbsoluteTime 1.0s → 2001-01-01T00:00:01Z
-        let m = parse_notification(&make_payload("방", Some("hi"), "42_99", 1.0, None)).unwrap();
+        // Fractional CFAbsoluteTime is preserved instead of truncated.
+        let m = parse_notification(&make_payload("방", Some("hi"), "42_99", 1.25, None)).unwrap();
         let ev = build_event(&m);
         assert_eq!(ev.chat_id, 42);
         assert_eq!(ev.log_id, 99);
         assert_eq!(ev.method, "notif");
         assert_eq!(ev.event_type, "notif_message");
-        assert!(ev.received_at.starts_with("2001-01-01T00:00:01"));
+        assert!(ev.received_at.starts_with("2001-01-01T00:00:01.250"));
     }
 
     #[test]
@@ -499,7 +835,13 @@ mod tests {
         // no kakao yet
         assert!(!kakao_notifier_registered(&conn).unwrap());
         conn.execute(
-            "INSERT INTO app(identifier) VALUES ('com.kakao.kakaotalkmac')",
+            "INSERT INTO app(identifier) VALUES ('com.example.kakao-helper')",
+            [],
+        )
+        .unwrap();
+        assert!(!kakao_notifier_registered(&conn).unwrap());
+        conn.execute(
+            "INSERT INTO app(identifier) VALUES ('com.kakao.KakaoTalkMac')",
             [],
         )
         .unwrap();
@@ -507,19 +849,244 @@ mod tests {
     }
 
     #[test]
-    fn should_emit_baselines_first_poll_then_dedups() {
-        let mut seen = HashSet::new();
-        // first poll: never emit, just baseline
-        assert!(!should_emit(&seen, (10, 1), true));
-        seen.insert((10, 1));
-        // later poll: a new key emits
-        assert!(should_emit(&seen, (10, 2), false));
-        seen.insert((10, 2));
-        // already seen: no re-emit
-        assert!(!should_emit(&seen, (10, 2), false));
-        // baselined key: no emit
-        assert!(!should_emit(&seen, (10, 1), false));
-        // same msg_id, different room: still emits (room-scoped key)
-        assert!(should_emit(&seen, (20, 1), false));
+    fn db_reader_filters_exact_bundle_and_orders_oldest_first() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("notifications.db");
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE app(app_id INTEGER PRIMARY KEY, identifier TEXT); \
+             CREATE TABLE record( \
+                 rec_id INTEGER PRIMARY KEY, app_id INTEGER, data BLOB, \
+                 request_date REAL, request_last_date REAL, delivered_date REAL \
+             ); \
+             INSERT INTO app(app_id, identifier) \
+                 VALUES (1, 'com.kakao.KakaoTalkMac'), \
+                        (2, 'com.example.kakao-helper');",
+        )
+        .unwrap();
+        let older = make_payload("방", Some("older"), "10_1", 1.0, None);
+        let newer = make_payload("방", Some("newer"), "10_2", 2.0, None);
+        let unrelated = make_payload("방", Some("unrelated"), "10_3", 3.0, None);
+        conn.execute(
+            "INSERT INTO record(rec_id, app_id, data, request_date) VALUES (1, 1, ?1, 2)",
+            [&newer],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO record(rec_id, app_id, data, request_date) VALUES (2, 1, ?1, 1)",
+            [&older],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO record(rec_id, app_id, data, request_date) VALUES (3, 2, ?1, 0)",
+            [&unrelated],
+        )
+        .unwrap();
+        drop(conn);
+
+        let snapshot = read_kakao_notifications(&path).unwrap();
+        assert!(snapshot.warnings.is_empty());
+        let bodies: Vec<_> = snapshot
+            .messages
+            .iter()
+            .map(|message| message.body.as_str())
+            .collect();
+        assert_eq!(bodies, vec!["older", "newer"]);
+    }
+
+    #[test]
+    fn malformed_payload_does_not_block_later_valid_notifications() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("notifications.db");
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE app(app_id INTEGER PRIMARY KEY, identifier TEXT); \
+             CREATE TABLE record( \
+                 rec_id INTEGER PRIMARY KEY, app_id INTEGER, data BLOB, \
+                 request_date REAL, request_last_date REAL, delivered_date REAL \
+             ); \
+             INSERT INTO app(app_id, identifier) VALUES (1, 'com.kakao.kakaotalkmac');",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO record(rec_id, app_id, data, request_date) VALUES (1, 1, ?1, 1)",
+            [vec![0xff, 0x00, 0xff]],
+        )
+        .unwrap();
+        let valid = make_payload("방", Some("later"), "10_2", 2.0, None);
+        conn.execute(
+            "INSERT INTO record(rec_id, app_id, data, request_date) VALUES (2, 1, ?1, 2)",
+            [&valid],
+        )
+        .unwrap();
+        drop(conn);
+
+        let snapshot = read_kakao_notifications(&path).unwrap();
+        assert_eq!(snapshot.warnings.len(), 1);
+        assert_eq!(snapshot.messages.len(), 1);
+        assert_eq!(snapshot.messages[0].body, "later");
+    }
+
+    #[test]
+    fn delivery_lease_covers_sequential_hook_and_webhook_timeouts() {
+        let mut config = test_hook_config();
+        config.command = Some("hook".to_string());
+        config.webhook_url = Some("https://example.invalid/hook".to_string());
+        config.hook_timeout_secs = 20;
+        config.webhook_timeout_secs = 10;
+
+        assert_eq!(delivery_lease_secs(&config), 90);
+    }
+
+    #[test]
+    fn db_reader_propagates_row_type_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("notifications.db");
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE app(app_id INTEGER PRIMARY KEY, identifier TEXT); \
+             CREATE TABLE record( \
+                 rec_id INTEGER PRIMARY KEY, app_id INTEGER, data BLOB, \
+                 request_date REAL, request_last_date REAL, delivered_date REAL \
+             ); \
+             INSERT INTO app(app_id, identifier) VALUES (1, 'com.kakao.kakaotalkmac'); \
+             INSERT INTO record(rec_id, app_id, data, request_date) \
+                 VALUES (1, 1, 'not a blob', 1);",
+        )
+        .unwrap();
+        drop(conn);
+
+        assert!(read_kakao_payloads(&path).is_err());
+    }
+
+    #[test]
+    fn tracker_baselines_then_emits_each_new_key_once() {
+        let baseline = vec![NotifMessage {
+            chat_name: "방".into(),
+            body: "old".into(),
+            room_id: 10,
+            msg_id: 1,
+            ts: 1.0,
+            attachment_path: String::new(),
+        }];
+        let mut next = baseline.clone();
+        next.push(NotifMessage {
+            body: "new".into(),
+            msg_id: 2,
+            ..baseline[0].clone()
+        });
+        // Duplicate DB rows for the same message still produce one event.
+        next.push(next[1].clone());
+
+        let mut tracker = NotificationTracker::default();
+        assert!(tracker.observe(&baseline).is_empty());
+        let fresh = tracker.observe(&next);
+        assert_eq!(fresh.len(), 1);
+        assert_eq!(fresh[0].msg_id, 2);
+        assert!(tracker.observe(&next).is_empty());
+    }
+
+    #[test]
+    fn replay_tracker_emits_retained_messages_once() {
+        let retained = vec![
+            NotifMessage {
+                chat_name: "방".into(),
+                body: "first".into(),
+                room_id: 10,
+                msg_id: 1,
+                ts: 1.0,
+                attachment_path: String::new(),
+            },
+            NotifMessage {
+                chat_name: "방".into(),
+                body: "duplicate".into(),
+                room_id: 10,
+                msg_id: 1,
+                ts: 1.0,
+                attachment_path: String::new(),
+            },
+        ];
+
+        let mut tracker = NotificationTracker::replay_existing();
+        let replayed = tracker.observe(&retained);
+        assert_eq!(replayed.len(), 1);
+        assert_eq!(replayed[0].body, "first");
+        assert!(tracker.observe(&retained).is_empty());
+    }
+
+    #[test]
+    fn tracker_is_bounded_to_the_current_notification_snapshot() {
+        let message = |room_id, msg_id| NotifMessage {
+            chat_name: "방".into(),
+            body: String::new(),
+            room_id,
+            msg_id,
+            ts: 1.0,
+            attachment_path: String::new(),
+        };
+        let mut tracker = NotificationTracker::default();
+        tracker.observe(&[message(10, 1), message(10, 2)]);
+        assert_eq!(tracker.previous.len(), 2);
+
+        tracker.observe(&[message(20, 1)]);
+        assert_eq!(tracker.previous, HashSet::from([(20, 1)]));
+    }
+
+    #[tokio::test]
+    async fn durable_drain_acknowledges_every_successful_delivery() {
+        let dir = tempfile::tempdir().unwrap();
+        let inbox = ReceiveInbox::open_at(&dir.path().join("receive.db")).unwrap();
+        let first = test_message(10, 1);
+        let second = test_message(10, 2);
+        inbox
+            .capture(&notification_event_id(&first), "notif", &first)
+            .unwrap();
+        inbox
+            .capture(&notification_event_id(&second), "notif", &second)
+            .unwrap();
+
+        let hook_config = test_hook_config();
+        NotifSink {
+            hook_config: &hook_config,
+            has_sinks: false,
+            json: false,
+        }
+        .drain(&inbox)
+        .await
+        .unwrap();
+
+        assert!(inbox.claim_next(60).unwrap().is_none());
+    }
+
+    #[test]
+    fn durable_drain_stops_only_for_a_matching_throttled_sink() {
+        let message = test_message(10, 1);
+        let mut hook_config = test_hook_config();
+        hook_config.command = Some("true".into());
+        hook_config.min_hook_interval_secs = 10;
+        let sink = NotifSink {
+            hook_config: &hook_config,
+            has_sinks: true,
+            json: false,
+        };
+
+        assert!(sink.uses_throttled_sink(&message));
+
+        hook_config.chat_names = vec!["different room".into()];
+        let filtered_sink = NotifSink {
+            hook_config: &hook_config,
+            has_sinks: true,
+            json: false,
+        };
+        assert!(!filtered_sink.uses_throttled_sink(&message));
+
+        hook_config.chat_names.clear();
+        hook_config.min_hook_interval_secs = 0;
+        let unthrottled_sink = NotifSink {
+            hook_config: &hook_config,
+            has_sinks: true,
+            json: false,
+        };
+        assert!(!unthrottled_sink.uses_throttled_sink(&message));
     }
 }

--- a/src/commands/notif_watch.rs
+++ b/src/commands/notif_watch.rs
@@ -736,15 +736,15 @@ mod tests {
         let p = make_payload(
             "테스트방",
             Some("안녕하세요"),
-            "474071844489941_3891201215281264642",
-            806497332.35,
+            "424242_999001",
+            800000000.25,
             None,
         );
         let m = parse_notification(&p).expect("should parse");
         assert_eq!(m.chat_name, "테스트방");
         assert_eq!(m.body, "안녕하세요");
-        assert_eq!(m.room_id, 474071844489941);
-        assert_eq!(m.msg_id, 3891201215281264642);
+        assert_eq!(m.room_id, 424242);
+        assert_eq!(m.msg_id, 999001);
         assert_eq!(m.attachment_path, "");
     }
 
@@ -753,8 +753,8 @@ mod tests {
         let p = make_payload(
             "테스트방",
             None,
-            "474071844489941_3891759278451095553",
-            806563858.72,
+            "424242_999002",
+            800000100.75,
             Some("/tmp/photo.jpeg"),
         );
         let m = parse_notification(&p).expect("should parse");
@@ -768,22 +768,10 @@ mod tests {
 
     #[test]
     fn same_room_shares_room_id_distinct_msg_id() {
-        let a = parse_notification(&make_payload(
-            "방",
-            Some("첫"),
-            "474071844489941_100",
-            1.0,
-            None,
-        ))
-        .unwrap();
-        let b = parse_notification(&make_payload(
-            "방",
-            Some("둘"),
-            "474071844489941_200",
-            2.0,
-            None,
-        ))
-        .unwrap();
+        let a =
+            parse_notification(&make_payload("방", Some("첫"), "424242_100", 1.0, None)).unwrap();
+        let b =
+            parse_notification(&make_payload("방", Some("둘"), "424242_200", 2.0, None)).unwrap();
         assert_eq!(a.room_id, b.room_id);
         assert_ne!(a.msg_id, b.msg_id);
     }

--- a/src/commands/notif_watch.rs
+++ b/src/commands/notif_watch.rs
@@ -192,6 +192,75 @@ fn read_kakao_payloads(db_path: &Path) -> Result<Vec<Vec<u8>>> {
     Ok(rows.filter_map(|r| r.ok()).collect())
 }
 
+/// Whether KakaoTalk is registered as a notifier in an open notification DB.
+/// Split out from [`check_access`] so it can be tested against an in-memory DB.
+fn kakao_notifier_registered(conn: &Connection) -> rusqlite::Result<bool> {
+    let count: i64 = conn.query_row(
+        "SELECT count(*) FROM app WHERE identifier LIKE '%kakao%'",
+        [],
+        |row| row.get(0),
+    )?;
+    Ok(count > 0)
+}
+
+/// Notification-receive readiness, for `doctor`.
+pub struct NotifAccess {
+    /// Whether the notification DB exists and could be opened read-only.
+    pub db_readable: bool,
+    /// Whether KakaoTalk is registered as a notifier (needs notifications on).
+    pub kakao_registered: bool,
+    /// Human-readable summary for the doctor row.
+    pub detail: String,
+}
+
+/// Probe whether `notif-watch` can work on this machine (read-only, no writes).
+pub fn check_access() -> NotifAccess {
+    let path = match notif_db_path() {
+        Ok(p) => p,
+        Err(e) => {
+            return NotifAccess {
+                db_readable: false,
+                kakao_registered: false,
+                detail: format!("cannot resolve home directory: {e}"),
+            }
+        }
+    };
+    if !path.exists() {
+        return NotifAccess {
+            db_readable: false,
+            kakao_registered: false,
+            detail: format!("notification DB not found at {}", path.display()),
+        };
+    }
+    let uri = format!("file:{}?mode=ro&immutable=1", path.display());
+    match Connection::open_with_flags(
+        &uri,
+        OpenFlags::SQLITE_OPEN_READ_ONLY
+            | OpenFlags::SQLITE_OPEN_URI
+            | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    ) {
+        Ok(conn) => {
+            let kakao = kakao_notifier_registered(&conn).unwrap_or(false);
+            NotifAccess {
+                db_readable: true,
+                kakao_registered: kakao,
+                detail: if kakao {
+                    "notification DB readable; KakaoTalk registered as notifier".to_string()
+                } else {
+                    "notification DB readable, but KakaoTalk is not a registered notifier — \
+                     enable KakaoTalk notifications in System Settings > Notifications"
+                        .to_string()
+                },
+            }
+        }
+        Err(e) => NotifAccess {
+            db_readable: false,
+            kakao_registered: false,
+            detail: format!("cannot open notification DB read-only: {e}"),
+        },
+    }
+}
+
 /// Poll the Notification Center DB and fire hooks/webhooks on new KakaoTalk
 /// messages. Runs until interrupted (Ctrl-C).
 pub fn cmd_notif_watch(options: NotifWatchOptions) -> Result<()> {
@@ -401,6 +470,21 @@ mod tests {
         assert_eq!(ev.event_type, "notif_message");
         // date=0 CFAbsoluteTime == 2001-01-01T00:00:00Z
         assert!(ev.received_at.starts_with("2001-01-01T00:00:00"));
+    }
+
+    #[test]
+    fn detects_kakao_notifier_registration() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE app(app_id INTEGER PRIMARY KEY, identifier TEXT);")
+            .unwrap();
+        // no kakao yet
+        assert!(!kakao_notifier_registered(&conn).unwrap());
+        conn.execute(
+            "INSERT INTO app(identifier) VALUES ('com.kakao.kakaotalkmac')",
+            [],
+        )
+        .unwrap();
+        assert!(kakao_notifier_registered(&conn).unwrap());
     }
 
     #[test]

--- a/src/commands/notif_watch.rs
+++ b/src/commands/notif_watch.rs
@@ -93,19 +93,32 @@ pub fn parse_notification(payload: &[u8]) -> Option<NotifMessage> {
     })
 }
 
-/// `date` may be stored as a real, an integer, or a numeric string.
+/// `date` may be a real, an integer, a numeric string, or a plist `Date`
+/// (CFDate). All resolve to a CFAbsoluteTime (seconds since 2001-01-01).
 fn value_as_f64(v: &Value) -> Option<f64> {
     match v {
         Value::Real(f) => Some(*f),
         Value::Integer(i) => i.as_signed().map(|n| n as f64),
         Value::String(s) => s.parse::<f64>().ok(),
+        Value::Date(d) => {
+            // plist::Date → SystemTime → Unix secs → CFAbsoluteTime
+            let unix = std::time::SystemTime::from(*d)
+                .duration_since(std::time::UNIX_EPOCH)
+                .ok()?
+                .as_secs_f64();
+            Some(unix - CFABSOLUTE_EPOCH_OFFSET)
+        }
         _ => None,
     }
 }
 
 /// CFAbsoluteTime → RFC3339 UTC string, matching the other watch sources'
-/// `received_at` format.
+/// `received_at` format. A non-positive/absent timestamp falls back to now()
+/// (the notification just arrived) rather than 2001-01-01.
 fn ts_to_rfc3339(cf: f64) -> String {
+    if cf <= 0.0 {
+        return chrono::Utc::now().to_rfc3339();
+    }
     let unix = cf + CFABSOLUTE_EPOCH_OFFSET;
     chrono::DateTime::<chrono::Utc>::from_timestamp(unix as i64, 0)
         .unwrap_or_else(chrono::Utc::now)
@@ -136,9 +149,10 @@ pub fn build_event(m: &NotifMessage) -> WatchMessageEvent {
 ///
 /// The first poll only records a baseline (so a backlog of notifications already
 /// sitting in Notification Center doesn't flood on startup); afterwards each
-/// `msg_id` fires exactly once.
-pub fn should_emit(seen: &HashSet<i64>, msg_id: i64, first: bool) -> bool {
-    !first && !seen.contains(&msg_id)
+/// `(room_id, msg_id)` fires exactly once. Keying on the room too (not just the
+/// message id) is safe even if the `iden` suffix turns out to be per-room.
+pub fn should_emit(seen: &HashSet<(i64, i64)>, key: (i64, i64), first: bool) -> bool {
+    !first && !seen.contains(&key)
 }
 
 /// Options for `notif-watch` (mirrors `AxWatchOptions`).
@@ -168,22 +182,26 @@ fn notif_db_path() -> Result<PathBuf> {
     Ok(home.join("Library/Group Containers/group.com.apple.usernoted/db2/db"))
 }
 
-/// Read the current KakaoTalk notification payloads, read-only.
-///
-// ponytail: opens immutable (ignores -wal) so a fresh connection each poll never
-// locks the live DB; the only cost is a notification still in the WAL isn't seen
-// until macOS checkpoints it into the main file — fine at watch cadence. Upgrade
-// path if that latency ever matters: copy db+db-wal to a temp file and open that.
-fn read_kakao_payloads(db_path: &Path) -> Result<Vec<Vec<u8>>> {
-    let uri = format!("file:{}?mode=ro&immutable=1", db_path.display());
-    let conn = Connection::open_with_flags(
+/// Open the notification DB read-only. Uses plain `mode=ro` (not `immutable=1`)
+/// so SQLite reads the `-wal` too — usernoted is WAL-mode and actively written,
+/// and the newest notifications sit in the WAL before they're checkpointed;
+/// ignoring it drops them. `mode=ro` also gives a consistent WAL snapshot, so a
+/// read that races the writer doesn't see a torn image. Single source of truth
+/// for how every code path opens this DB.
+fn open_notif_db(db_path: &Path) -> Result<Connection> {
+    let uri = format!("file:{}?mode=ro", db_path.display());
+    Connection::open_with_flags(
         &uri,
         OpenFlags::SQLITE_OPEN_READ_ONLY
             | OpenFlags::SQLITE_OPEN_URI
             | OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )
-    .with_context(|| format!("open notification DB: {}", db_path.display()))?;
+    .with_context(|| format!("open notification DB: {}", db_path.display()))
+}
 
+/// Read the current KakaoTalk notification payloads, read-only.
+fn read_kakao_payloads(db_path: &Path) -> Result<Vec<Vec<u8>>> {
+    let conn = open_notif_db(db_path)?;
     let mut stmt = conn.prepare(
         "SELECT r.data FROM record r JOIN app a ON r.app_id = a.app_id \
          WHERE a.identifier LIKE '%kakao%' AND r.data IS NOT NULL",
@@ -232,13 +250,7 @@ pub fn check_access() -> NotifAccess {
             detail: format!("notification DB not found at {}", path.display()),
         };
     }
-    let uri = format!("file:{}?mode=ro&immutable=1", path.display());
-    match Connection::open_with_flags(
-        &uri,
-        OpenFlags::SQLITE_OPEN_READ_ONLY
-            | OpenFlags::SQLITE_OPEN_URI
-            | OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    ) {
+    match open_notif_db(&path) {
         Ok(conn) => {
             let kakao = kakao_notifier_registered(&conn).unwrap_or(false);
             NotifAccess {
@@ -300,16 +312,17 @@ pub fn cmd_notif_watch(options: NotifWatchOptions) -> Result<()> {
     let has_sinks = hook_config.command.is_some() || hook_config.webhook_url.is_some();
 
     let db_path = notif_db_path()?;
+    // A 0s interval would busy-loop and hammer the DB; keep at least 1s.
+    let interval_secs = options.interval_secs.max(1);
 
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
-        // ponytail: unbounded set of seen msg_ids. A long-running watch grows it
-        // slowly; bound to a ring buffer only if memory ever matters.
-        let mut seen: HashSet<i64> = HashSet::new();
+        // ponytail: unbounded set of seen (room_id, msg_id) keys. A long-running
+        // watch grows it slowly; bound to a ring buffer only if memory matters.
+        let mut seen: HashSet<(i64, i64)> = HashSet::new();
         let mut first = true;
         eprintln!(
-            "[notif-watch] polling macOS notification center every {}s (Ctrl-C to stop)",
-            options.interval_secs
+            "[notif-watch] polling macOS notification center every {interval_secs}s (Ctrl-C to stop)"
         );
         loop {
             match read_kakao_payloads(&db_path) {
@@ -318,7 +331,8 @@ pub fn cmd_notif_watch(options: NotifWatchOptions) -> Result<()> {
                         let Some(msg) = parse_notification(payload) else {
                             continue;
                         };
-                        if should_emit(&seen, msg.msg_id, first) {
+                        let key = (msg.room_id, msg.msg_id);
+                        if should_emit(&seen, key, first) {
                             let event = build_event(&msg);
                             let human_line = format!(
                                 "[notif-watch] {}: {}",
@@ -339,7 +353,7 @@ pub fn cmd_notif_watch(options: NotifWatchOptions) -> Result<()> {
                             )
                             .await?;
                         }
-                        seen.insert(msg.msg_id);
+                        seen.insert(key);
                     }
                     first = false;
                 }
@@ -347,7 +361,7 @@ pub fn cmd_notif_watch(options: NotifWatchOptions) -> Result<()> {
                     eprintln!("[notif-watch] read failed (retrying next poll): {e}");
                 }
             }
-            tokio::time::sleep(Duration::from_secs(options.interval_secs)).await;
+            tokio::time::sleep(Duration::from_secs(interval_secs)).await;
         }
     })
 }
@@ -459,17 +473,22 @@ mod tests {
 
     #[test]
     fn build_event_maps_iden_and_timestamp() {
-        let m = parse_notification(&make_payload(
-            "방", Some("hi"), "42_99", 0.0, None,
-        ))
-        .unwrap();
+        // CFAbsoluteTime 1.0s → 2001-01-01T00:00:01Z
+        let m = parse_notification(&make_payload("방", Some("hi"), "42_99", 1.0, None)).unwrap();
         let ev = build_event(&m);
         assert_eq!(ev.chat_id, 42);
         assert_eq!(ev.log_id, 99);
         assert_eq!(ev.method, "notif");
         assert_eq!(ev.event_type, "notif_message");
-        // date=0 CFAbsoluteTime == 2001-01-01T00:00:00Z
-        assert!(ev.received_at.starts_with("2001-01-01T00:00:00"));
+        assert!(ev.received_at.starts_with("2001-01-01T00:00:01"));
+    }
+
+    #[test]
+    fn absent_or_zero_timestamp_falls_back_to_now_not_2001() {
+        let m = parse_notification(&make_payload("방", Some("hi"), "42_99", 0.0, None)).unwrap();
+        let ev = build_event(&m);
+        // must NOT collapse to the CFAbsolute epoch
+        assert!(!ev.received_at.starts_with("2001-01-01"));
     }
 
     #[test]
@@ -491,14 +510,16 @@ mod tests {
     fn should_emit_baselines_first_poll_then_dedups() {
         let mut seen = HashSet::new();
         // first poll: never emit, just baseline
-        assert!(!should_emit(&seen, 1, true));
-        seen.insert(1);
-        // later poll: a new id emits
-        assert!(should_emit(&seen, 2, false));
-        seen.insert(2);
+        assert!(!should_emit(&seen, (10, 1), true));
+        seen.insert((10, 1));
+        // later poll: a new key emits
+        assert!(should_emit(&seen, (10, 2), false));
+        seen.insert((10, 2));
         // already seen: no re-emit
-        assert!(!should_emit(&seen, 2, false));
-        // baselined id: no emit
-        assert!(!should_emit(&seen, 1, false));
+        assert!(!should_emit(&seen, (10, 2), false));
+        // baselined key: no emit
+        assert!(!should_emit(&seen, (10, 1), false));
+        // same msg_id, different room: still emits (room-scoped key)
+        assert!(should_emit(&seen, (20, 1), false));
     }
 }

--- a/src/commands/safe_send.rs
+++ b/src/commands/safe_send.rs
@@ -1,0 +1,225 @@
+use std::io::{IsTerminal, Write};
+
+use anyhow::Result;
+
+use crate::safe_send::{ProposeSend, SafeSendOutbox, SendTransport, TransportOutcome};
+use crate::util::{
+    confirm, escape_terminal_text, output_json, truncate, validate_outbound_message,
+};
+
+pub struct ProposeOptions {
+    pub chat_name: String,
+    pub message: String,
+    pub reply_to: Option<(i64, i64)>,
+    pub idempotency_key: Option<String>,
+    pub json: bool,
+}
+
+pub struct ApproveOptions {
+    pub intent_id: String,
+    pub allow_ax_send: bool,
+    pub allowed_chats: Vec<String>,
+    pub unattended: bool,
+    pub json: bool,
+}
+
+struct AxSendTransport;
+
+impl SendTransport for AxSendTransport {
+    fn send(&mut self, chat_name: &str, message: &str) -> TransportOutcome {
+        match crate::ax_send::send_via_ax_classified(chat_name, message) {
+            Ok(crate::ax_send::AxDeliveryOutcome::Verified) => TransportOutcome::Verified,
+            Ok(crate::ax_send::AxDeliveryOutcome::Uncertain { reason }) => {
+                TransportOutcome::Uncertain { reason }
+            }
+            Err(error) => TransportOutcome::NotSent {
+                reason: error.to_string(),
+            },
+        }
+    }
+}
+
+fn require_approval_session(
+    unattended: bool,
+    stdin_is_terminal: bool,
+    allow_ax_send: bool,
+) -> Result<()> {
+    if unattended || !stdin_is_terminal {
+        anyhow::bail!(
+            "safe-send approval requires an interactive terminal; there is no unattended bypass"
+        );
+    }
+    if !allow_ax_send {
+        anyhow::bail!(
+            "AX sending is disabled; set safety.allow_ax_send = true only after reviewing the safe-send proposal"
+        );
+    }
+    Ok(())
+}
+
+fn require_allowed_approval_chat(allowed_chats: &[String], chat_name: &str) -> Result<()> {
+    if !allowed_chats.iter().any(|allowed| allowed == chat_name) {
+        anyhow::bail!(
+            "chat {:?} is not in safety.allowed_send_chats; refusing approval",
+            chat_name
+        );
+    }
+    Ok(())
+}
+
+pub fn cmd_propose(options: ProposeOptions) -> Result<()> {
+    validate_outbound_message(&options.message)?;
+    let outbox = SafeSendOutbox::open()?;
+    let intent = outbox.propose(ProposeSend {
+        chat_name: &options.chat_name,
+        message: &options.message,
+        reply_to: options.reply_to,
+        idempotency_key: options.idempotency_key.as_deref(),
+    })?;
+
+    if options.json {
+        output_json(&intent)?;
+    } else {
+        println!("Safe-send intent stored; this command sent no message.");
+        println!(
+            "  state:   {}",
+            serde_json::to_value(intent.state)?
+                .as_str()
+                .unwrap_or("unknown")
+        );
+        println!("  intent:  {}", intent.intent_id);
+        println!("  target:  {}", escape_terminal_text(&intent.chat_name));
+        println!(
+            "  message: {}",
+            serde_json::to_string(&escape_terminal_text(&truncate(&intent.message, 120)))?
+        );
+        println!("  code:    {}", intent.approval_code);
+        if intent.state == crate::safe_send::SendState::Proposed {
+            println!(
+                "Review it, then run: openkakao-cli safe-send approve {}",
+                intent.intent_id
+            );
+        }
+    }
+    Ok(())
+}
+
+pub fn cmd_list(json: bool) -> Result<()> {
+    let outbox = SafeSendOutbox::open()?;
+    let intents = outbox.list_active()?;
+    if json {
+        output_json(&intents)?;
+    } else if intents.is_empty() {
+        println!("No active safe-send intents.");
+    } else {
+        for intent in intents {
+            println!(
+                "{} [{}] {}: {} (code {})",
+                intent.intent_id,
+                serde_json::to_value(intent.state)?
+                    .as_str()
+                    .unwrap_or("unknown"),
+                escape_terminal_text(&intent.chat_name),
+                serde_json::to_string(&escape_terminal_text(&truncate(&intent.message, 80)))?,
+                intent.approval_code
+            );
+        }
+    }
+    Ok(())
+}
+
+pub fn cmd_approve(options: ApproveOptions) -> Result<()> {
+    require_approval_session(
+        options.unattended,
+        std::io::stdin().is_terminal(),
+        options.allow_ax_send,
+    )?;
+
+    let mut outbox = SafeSendOutbox::open()?;
+    let intent = outbox.get(&options.intent_id)?;
+    require_allowed_approval_chat(&options.allowed_chats, &intent.chat_name)?;
+
+    validate_outbound_message(&intent.message)?;
+    eprintln!("Safe-send approval review:");
+    eprintln!("  intent:  {}", intent.intent_id);
+    eprintln!("  target:  {}", escape_terminal_text(&intent.chat_name));
+    eprintln!(
+        "  message: {}",
+        serde_json::to_string(&escape_terminal_text(&intent.message))?
+    );
+    if let Some((chat_id, log_id)) = intent.reply_to {
+        eprintln!("  reply:   chat {chat_id}, log {log_id}");
+    }
+    eprint!("Type the 12-character approval code: ");
+    std::io::stderr().flush()?;
+    let mut approval_code = String::new();
+    std::io::stdin().read_line(&mut approval_code)?;
+
+    let sent = outbox.approve_and_send(
+        &intent.intent_id,
+        approval_code.trim(),
+        &mut AxSendTransport,
+    )?;
+    if options.json {
+        output_json(&sent)?;
+    } else {
+        println!("Safe-send completed for intent {}.", sent.intent_id);
+    }
+    Ok(())
+}
+
+pub fn cmd_cancel(intent_id: &str, skip_confirm: bool, json: bool) -> Result<()> {
+    let outbox = SafeSendOutbox::open()?;
+    let intent = outbox.get(intent_id)?;
+    if !skip_confirm {
+        if !std::io::stdin().is_terminal() {
+            anyhow::bail!("safe-send cancel requires an interactive terminal or --yes");
+        }
+        eprint!(
+            "Cancel safe-send intent {} for {:?}?\n[y/N] ",
+            intent.intent_id, intent.chat_name
+        );
+        std::io::stderr().flush()?;
+        if !confirm()? {
+            println!("Cancelled nothing.");
+            return Ok(());
+        }
+    }
+
+    let cancelled = outbox.cancel(intent_id)?;
+    if json {
+        output_json(&cancelled)?;
+    } else {
+        println!("Safe-send intent {} cancelled.", cancelled.intent_id);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn approval_session_requires_a_human_terminal_and_ax_opt_in() {
+        let unattended = require_approval_session(true, true, true).unwrap_err();
+        assert!(unattended.to_string().contains("no unattended bypass"));
+
+        let non_terminal = require_approval_session(false, false, true).unwrap_err();
+        assert!(non_terminal.to_string().contains("interactive terminal"));
+
+        let disabled = require_approval_session(false, true, false).unwrap_err();
+        assert!(disabled.to_string().contains("AX sending is disabled"));
+
+        require_approval_session(false, true, true).unwrap();
+    }
+
+    #[test]
+    fn approval_chat_allowlist_requires_an_exact_full_name() {
+        let allowed = vec!["허용된 방".to_string()];
+
+        require_allowed_approval_chat(&allowed, "허용된 방").unwrap();
+        assert!(require_allowed_approval_chat(&allowed, "허용된").is_err());
+        assert!(require_allowed_approval_chat(&allowed, "허용된 방과 다른 방").is_err());
+        assert!(require_allowed_approval_chat(&[], "허용된 방").is_err());
+    }
+}

--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -1269,6 +1269,58 @@ pub fn cmd_watch(options: WatchOptions) -> Result<()> {
     })
 }
 
+/// Emit one watch event to every configured sink, then apply the shared
+/// emit→hook→webhook→fail_fast policy. Every watch source (`watch`, `ax-watch`,
+/// `notif-watch`) routes through here so that policy lives in exactly one place.
+///
+/// - `json`: print the event as NDJSON to stdout; otherwise write `human_line`
+///   (already formatted by the caller) to stderr.
+/// - `has_sinks`: whether a command hook or webhook is configured.
+/// - `source_label`: prefixes error lines, e.g. `[ax-watch] hook failed: …`.
+///
+/// Returns `Err` only when a sink fails **and** `fail_fast` is set; otherwise a
+/// sink failure is logged and swallowed so the poll loop keeps running.
+pub async fn dispatch_event(
+    event: &WatchMessageEvent,
+    hook_config: &WatchHookConfig,
+    has_sinks: bool,
+    json: bool,
+    human_line: &str,
+    source_label: &str,
+) -> Result<()> {
+    if json {
+        println!("{}", event.as_json());
+    } else {
+        eprintln!("{human_line}");
+    }
+
+    if has_sinks && watch_hook_matches(hook_config, event) {
+        if hook_config.command.is_some() {
+            if let Err(e) = run_watch_command_hook_async(hook_config, event).await {
+                eprintln!("[{source_label}] hook failed: {e}");
+                if hook_config.fail_fast {
+                    return Err(e);
+                }
+            }
+        }
+        if hook_config.webhook_url.is_some() {
+            let cfg = hook_config.clone();
+            let ev = event.clone();
+            if let Err(e) = tokio::task::spawn_blocking(move || run_watch_webhook(&cfg, &ev))
+                .await
+                .unwrap_or_else(|e| Err(anyhow::anyhow!(e)))
+            {
+                eprintln!("[{source_label}] webhook failed: {e}");
+                if hook_config.fail_fast {
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -206,10 +206,16 @@ pub fn validate_webhook_url(webhook_url: &str, allow_insecure_webhooks: bool) ->
 
 /// Execute a local hook command asynchronously using tokio::process::Command
 /// with proper async timeout instead of polling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SinkDelivery {
+    Delivered,
+    RateLimited { remaining_secs: u64 },
+}
+
 pub async fn run_watch_command_hook_async(
     config: &WatchHookConfig,
     event: &WatchMessageEvent,
-) -> Result<()> {
+) -> Result<SinkDelivery> {
     let command = config
         .command
         .as_deref()
@@ -220,7 +226,9 @@ pub async fn run_watch_command_hook_async(
             "[guard/hook] Skipping local hook for chat {} log {}: {}s rate-limit remaining.",
             event.chat_id, event.log_id, remaining
         );
-        return Ok(());
+        return Ok(SinkDelivery::RateLimited {
+            remaining_secs: remaining,
+        });
     }
     mark_hook_attempt()?;
     let payload = serde_json::to_vec_pretty(&event.as_json())?;
@@ -246,12 +254,17 @@ pub async fn run_watch_command_hook_async(
 
     if let Some(mut stdin) = child.stdin.take() {
         use tokio::io::AsyncWriteExt;
-        let _ = stdin.write_all(&payload).await;
+        if let Err(error) = stdin.write_all(&payload).await {
+            let _ = child.kill().await;
+            return Err(anyhow::anyhow!(
+                "failed to write the complete event payload to hook stdin: {error}"
+            ));
+        }
     }
 
     let timeout = Duration::from_secs(config.hook_timeout_secs.max(1));
     match tokio::time::timeout(timeout, child.wait()).await {
-        Ok(Ok(status)) if status.success() => Ok(()),
+        Ok(Ok(status)) if status.success() => Ok(SinkDelivery::Delivered),
         Ok(Ok(status)) => Err(anyhow::anyhow!(
             "hook command exited with status {}",
             status
@@ -270,7 +283,10 @@ pub async fn run_watch_command_hook_async(
     }
 }
 
-pub fn run_watch_webhook(config: &WatchHookConfig, event: &WatchMessageEvent) -> Result<()> {
+pub fn run_watch_webhook(
+    config: &WatchHookConfig,
+    event: &WatchMessageEvent,
+) -> Result<SinkDelivery> {
     let webhook_url = config
         .webhook_url
         .as_deref()
@@ -281,7 +297,9 @@ pub fn run_watch_webhook(config: &WatchHookConfig, event: &WatchMessageEvent) ->
             "[guard/webhook] Skipping webhook for chat {} log {}: {}s rate-limit remaining.",
             event.chat_id, event.log_id, remaining
         );
-        return Ok(());
+        return Ok(SinkDelivery::RateLimited {
+            remaining_secs: remaining,
+        });
     }
     mark_webhook_attempt()?;
     let payload_json = match &config.webhook_format {
@@ -342,9 +360,7 @@ pub fn run_watch_webhook(config: &WatchHookConfig, event: &WatchMessageEvent) ->
         WebhookFormat::Raw => event.as_json(),
     };
     let payload = serde_json::to_vec(&payload_json)?;
-    let client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(config.webhook_timeout_secs.max(1)))
-        .build()?;
+    let client = build_webhook_client(config.webhook_timeout_secs)?;
     let mut request = client
         .post(webhook_url)
         .header("Content-Type", "application/json");
@@ -363,13 +379,23 @@ pub fn run_watch_webhook(config: &WatchHookConfig, event: &WatchMessageEvent) ->
 
     let response = request.body(payload).send()?;
     if response.status().is_success() {
-        Ok(())
+        Ok(SinkDelivery::Delivered)
     } else {
         Err(anyhow::anyhow!(
             "webhook returned non-success status {}",
             response.status()
         ))
     }
+}
+
+fn build_webhook_client(timeout_secs: u64) -> Result<reqwest::blocking::Client> {
+    Ok(reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(timeout_secs.max(1)))
+        // Validation applies to the configured destination only. Following a
+        // redirect could leak the payload or caller-supplied headers to an
+        // unvalidated host/scheme, so webhook redirects are fail-closed.
+        .redirect(reqwest::redirect::Policy::none())
+        .build()?)
 }
 
 fn reconnect_delay(attempt: u32, initial_secs: u64, max_secs: u64) -> Duration {
@@ -538,7 +564,7 @@ async fn handle_msg_packet(
         if watch_hook_matches(config, &event) {
             if config.command.is_some() {
                 match run_watch_command_hook_async(config, &event).await {
-                    Ok(()) => {}
+                    Ok(_) => {}
                     Err(e) => {
                         eprintln!("[watch] Hook failed: {}", e);
                         if config.fail_fast {
@@ -555,7 +581,7 @@ async fn handle_msg_packet(
                 })
                 .await
                 {
-                    Ok(Ok(())) => {}
+                    Ok(Ok(_)) => {}
                     Ok(Err(e)) => {
                         eprintln!("[watch] Webhook failed: {}", e);
                         if config.fail_fast {
@@ -764,7 +790,7 @@ async fn handle_syncdlmsg_packet(
         if watch_hook_matches(config, &event) {
             if config.command.is_some() {
                 match run_watch_command_hook_async(config, &event).await {
-                    Ok(()) => {}
+                    Ok(_) => {}
                     Err(e) => {
                         eprintln!("[watch] Hook failed: {}", e);
                         if config.fail_fast {
@@ -781,7 +807,7 @@ async fn handle_syncdlmsg_packet(
                 })
                 .await
                 {
-                    Ok(Ok(())) => {}
+                    Ok(Ok(_)) => {}
                     Ok(Err(e)) => {
                         eprintln!("[watch] Webhook failed: {}", e);
                         if config.fail_fast {
@@ -1269,17 +1295,32 @@ pub fn cmd_watch(options: WatchOptions) -> Result<()> {
     })
 }
 
-/// Emit one watch event to every configured sink, then apply the shared
-/// emit→hook→webhook→fail_fast policy. Every watch source (`watch`, `ax-watch`,
-/// `notif-watch`) routes through here so that policy lives in exactly one place.
+/// Emit one local-watch event to every configured sink, then apply the shared
+/// emit→hook→webhook→fail_fast policy used by `ax-watch` and `notif-watch`.
 ///
 /// - `json`: print the event as NDJSON to stdout; otherwise write `human_line`
 ///   (already formatted by the caller) to stderr.
 /// - `has_sinks`: whether a command hook or webhook is configured.
 /// - `source_label`: prefixes error lines, e.g. `[ax-watch] hook failed: …`.
 ///
-/// Returns `Err` only when a sink fails **and** `fail_fast` is set; otherwise a
-/// sink failure is logged and swallowed so the poll loop keeps running.
+/// Returns `Err` only when a sink fails **and** `fail_fast` is set. Otherwise
+/// failures are reported to callers so durable receivers can defer their
+/// acknowledgement while ordinary watch loops keep running.
+#[derive(Debug, Default)]
+pub struct DispatchReport {
+    pub sink_errors: Vec<String>,
+}
+
+impl DispatchReport {
+    pub fn is_success(&self) -> bool {
+        self.sink_errors.is_empty()
+    }
+
+    pub fn error_summary(&self) -> String {
+        self.sink_errors.join("; ")
+    }
+}
+
 pub async fn dispatch_event(
     event: &WatchMessageEvent,
     hook_config: &WatchHookConfig,
@@ -1287,7 +1328,8 @@ pub async fn dispatch_event(
     json: bool,
     human_line: &str,
     source_label: &str,
-) -> Result<()> {
+) -> Result<DispatchReport> {
+    let mut report = DispatchReport::default();
     if json {
         println!("{}", event.as_json());
     } else {
@@ -1296,34 +1338,55 @@ pub async fn dispatch_event(
 
     if has_sinks && watch_hook_matches(hook_config, event) {
         if hook_config.command.is_some() {
-            if let Err(e) = run_watch_command_hook_async(hook_config, event).await {
-                eprintln!("[{source_label}] hook failed: {e}");
-                if hook_config.fail_fast {
-                    return Err(e);
+            match run_watch_command_hook_async(hook_config, event).await {
+                Ok(SinkDelivery::Delivered) => {}
+                Ok(SinkDelivery::RateLimited { remaining_secs }) => {
+                    report
+                        .sink_errors
+                        .push(format!("hook rate-limited for {remaining_secs}s"));
+                }
+                Err(e) => {
+                    eprintln!("[{source_label}] hook failed: {e}");
+                    if hook_config.fail_fast {
+                        return Err(e);
+                    }
+                    report.sink_errors.push(format!("hook: {e}"));
                 }
             }
         }
         if hook_config.webhook_url.is_some() {
             let cfg = hook_config.clone();
             let ev = event.clone();
-            if let Err(e) = tokio::task::spawn_blocking(move || run_watch_webhook(&cfg, &ev))
+            match tokio::task::spawn_blocking(move || run_watch_webhook(&cfg, &ev))
                 .await
                 .unwrap_or_else(|e| Err(anyhow::anyhow!(e)))
             {
-                eprintln!("[{source_label}] webhook failed: {e}");
-                if hook_config.fail_fast {
-                    return Err(e);
+                Ok(SinkDelivery::Delivered) => {}
+                Ok(SinkDelivery::RateLimited { remaining_secs }) => {
+                    report
+                        .sink_errors
+                        .push(format!("webhook rate-limited for {remaining_secs}s"));
+                }
+                Err(e) => {
+                    eprintln!("[{source_label}] webhook failed: {e}");
+                    if hook_config.fail_fast {
+                        return Err(e);
+                    }
+                    report.sink_errors.push(format!("webhook: {e}"));
                 }
             }
         }
     }
 
-    Ok(())
+    Ok(report)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
 
     fn default_test_hook_config() -> WatchHookConfig {
         WatchHookConfig {
@@ -1378,5 +1441,38 @@ mod tests {
         let mut event = default_test_event();
         event.chat_name = "아무개".to_string();
         assert!(watch_hook_matches(&config, &event));
+    }
+
+    #[test]
+    fn webhook_client_does_not_follow_redirects() {
+        let redirect_target = TcpListener::bind("127.0.0.1:0").unwrap();
+        redirect_target.set_nonblocking(true).unwrap();
+        let target_url = format!("http://{}/leak", redirect_target.local_addr().unwrap());
+
+        let redirect_server = TcpListener::bind("127.0.0.1:0").unwrap();
+        let redirect_url = format!("http://{}/hook", redirect_server.local_addr().unwrap());
+        let server = thread::spawn(move || {
+            let (mut stream, _) = redirect_server.accept().unwrap();
+            let mut request = [0u8; 4096];
+            let _ = stream.read(&mut request).unwrap();
+            write!(
+                stream,
+                "HTTP/1.1 302 Found\r\nLocation: {target_url}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            )
+            .unwrap();
+        });
+
+        let response = build_webhook_client(1)
+            .unwrap()
+            .post(redirect_url)
+            .body("sensitive payload")
+            .send()
+            .unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::FOUND);
+        server.join().unwrap();
+
+        thread::sleep(Duration::from_millis(50));
+        let error = redirect_target.accept().unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::WouldBlock);
     }
 }

--- a/src/human_auth.rs
+++ b/src/human_auth.rs
@@ -1,0 +1,102 @@
+//! OS-mediated user-presence verification for irreversible local actions.
+
+use anyhow::Result;
+
+fn process_validation_error(code: i32) -> Option<&'static str> {
+    match code {
+        0 => None,
+        10 => Some("could not bind a macOS code-signing object to the KakaoTalk process"),
+        11 => Some("the running KakaoTalk process failed Apple-anchored dynamic code validation"),
+        12 => Some("the running process does not have KakaoTalk's expected bundle/team identity"),
+        _ => Some("the running KakaoTalk process failed code-signing validation unexpectedly"),
+    }
+}
+
+fn authentication_error(code: i32) -> Option<&'static str> {
+    match code {
+        0 => None,
+        1 => Some(
+            "macOS device-owner authentication is unavailable; configure Touch ID or a login password before approving sends",
+        ),
+        2 => Some("macOS device-owner authentication was cancelled or denied; no message was sent"),
+        3 => Some("macOS device-owner authentication timed out; no message was sent"),
+        _ => Some("macOS device-owner authentication failed unexpectedly; no message was sent"),
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub fn require_device_owner_auth(reason: &str) -> Result<()> {
+    use std::ffi::CString;
+    use std::os::raw::{c_char, c_int};
+
+    unsafe extern "C" {
+        fn openkakao_authenticate_device_owner(reason_utf8: *const c_char) -> c_int;
+    }
+
+    let reason = CString::new(reason)?;
+    let code = unsafe { openkakao_authenticate_device_owner(reason.as_ptr()) };
+    if let Some(message) = authentication_error(code) {
+        anyhow::bail!(message);
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+pub fn validate_kakaotalk_process(pid: i32) -> Result<()> {
+    use std::os::raw::c_int;
+
+    unsafe extern "C" {
+        fn openkakao_validate_kakaotalk_process(pid: c_int) -> c_int;
+    }
+
+    let code = unsafe { openkakao_validate_kakaotalk_process(pid) };
+    if let Some(message) = process_validation_error(code) {
+        anyhow::bail!(message);
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn require_device_owner_auth(_reason: &str) -> Result<()> {
+    anyhow::bail!("safe-send approval with device-owner authentication is only supported on macOS")
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn validate_kakaotalk_process(_pid: i32) -> Result<()> {
+    anyhow::bail!("KakaoTalk process validation is only supported on macOS")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_authentication_codes_fail_closed() {
+        assert_eq!(authentication_error(0), None);
+        assert!(authentication_error(1).unwrap().contains("unavailable"));
+        assert!(authentication_error(2).unwrap().contains("denied"));
+        assert!(authentication_error(3).unwrap().contains("timed out"));
+        assert!(authentication_error(99).unwrap().contains("unexpectedly"));
+    }
+
+    #[test]
+    fn process_validation_codes_fail_closed() {
+        assert_eq!(process_validation_error(0), None);
+        assert!(process_validation_error(10).unwrap().contains("bind"));
+        assert!(process_validation_error(11)
+            .unwrap()
+            .contains("Apple-anchored"));
+        assert!(process_validation_error(12)
+            .unwrap()
+            .contains("bundle/team"));
+        assert!(process_validation_error(99)
+            .unwrap()
+            .contains("unexpectedly"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn process_validation_rejects_this_non_kakao_test_process() {
+        assert!(validate_kakaotalk_process(std::process::id() as i32).is_err());
+    }
+}

--- a/src/human_auth.rs
+++ b/src/human_auth.rs
@@ -2,6 +2,7 @@
 
 use anyhow::Result;
 
+#[cfg(any(test, target_os = "macos"))]
 fn process_validation_error(code: i32) -> Option<&'static str> {
     match code {
         0 => None,
@@ -12,6 +13,7 @@ fn process_validation_error(code: i32) -> Option<&'static str> {
     }
 }
 
+#[cfg(any(test, target_os = "macos"))]
 fn authentication_error(code: i32) -> Option<&'static str> {
     match code {
         0 => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 pub mod error;
+pub mod human_auth;
 pub mod local_db;
 pub mod loco;
 pub mod message_db;
 pub mod model;
+pub mod receive_inbox;
+pub mod safe_send;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,9 @@ mod loco_helpers;
 mod media;
 mod message_db;
 mod model;
+mod receive_inbox;
 mod rest;
+mod safe_send;
 mod state;
 mod util;
 
@@ -535,6 +537,11 @@ enum Commands {
         #[arg(long, help = "Preview the action without executing")]
         dry_run: bool,
     },
+    /// Queue and manually approve a crash-safe AX send
+    SafeSend {
+        #[command(subcommand)]
+        action: SafeSendAction,
+    },
     /// Read recent messages via AX automation (no server contact, no local
     /// DB access — scrapes the open KakaoTalk chat window directly)
     AxRead {
@@ -569,6 +576,16 @@ enum Commands {
     NotifWatch {
         #[arg(long, default_value_t = 3)]
         interval: u64,
+        #[arg(
+            long,
+            help = "Emit KakaoTalk messages already retained in Notification Center on startup"
+        )]
+        replay_existing: bool,
+        #[arg(
+            long,
+            help = "Persist before delivery, retry after restart, and reconcile retained notifications"
+        )]
+        durable: bool,
         #[arg(long)]
         hook_cmd: Option<String>,
         #[arg(long)]
@@ -591,6 +608,31 @@ enum Commands {
         /// Also test LOCO booking connectivity (makes network request)
         #[arg(long)]
         loco: bool,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum SafeSendAction {
+    /// Persist a send proposal without sending anything
+    Propose {
+        chat_name: String,
+        message: String,
+        #[arg(long, requires = "reply_log_id")]
+        reply_chat_id: Option<i64>,
+        #[arg(long, requires = "reply_chat_id")]
+        reply_log_id: Option<i64>,
+        #[arg(long)]
+        idempotency_key: Option<String>,
+    },
+    /// List proposals and uncertain send attempts requiring attention
+    List,
+    /// Review and send from an interactive terminal; global unattended flags are rejected
+    Approve { intent_id: String },
+    /// Permanently cancel a proposed or uncertain intent
+    Cancel {
+        intent_id: String,
+        #[arg(long, short = 'y', help = "Skip confirmation prompt")]
+        yes: bool,
     },
 }
 
@@ -647,6 +689,29 @@ fn require_allowed_send_chat(config: &config::OpenKakaoConfig, chat_name: &str) 
     Ok(())
 }
 
+/// Whether this command can benefit from the warning about broken server-login
+/// flows. Purely local commands should stay quiet: the warning is unrelated to
+/// their operation and is especially noisy for long-running watch processes.
+fn should_warn_about_server_login(command: &Commands) -> bool {
+    !matches!(
+        command,
+        Commands::AuthStatus
+            | Commands::Completions { .. }
+            | Commands::CacheSearch { .. }
+            | Commands::CacheStats
+            | Commands::LocalChats { .. }
+            | Commands::LocalRead { .. }
+            | Commands::LocalSearch { .. }
+            | Commands::LocalSchema
+            | Commands::LocalSend { .. }
+            | Commands::SafeSend { .. }
+            | Commands::AxRead { .. }
+            | Commands::AxWatch { .. }
+            | Commands::NotifWatch { .. }
+            | Commands::Doctor { .. }
+    )
+}
+
 fn main() -> Result<()> {
     let cli = Cli::parse();
     let config = load_config()?;
@@ -676,10 +741,10 @@ fn main() -> Result<()> {
     }
 
     // Server-login warning — printed to stderr so it never corrupts JSON on
-    // stdout. Silenced with OPENKAKAO_CLI_NO_DEPRECATION=1 for scripted
-    // local-only use. `local-send`/`ax-read` need neither login nor this
-    // warning, since they never touch Kakao's servers.
-    if std::env::var_os("OPENKAKAO_CLI_NO_DEPRECATION").is_none() {
+    // stdout. Local-only commands do not show an unrelated auth warning.
+    if should_warn_about_server_login(&cli.command)
+        && std::env::var_os("OPENKAKAO_CLI_NO_DEPRECATION").is_none()
+    {
         eprintln!("⚠️  Server login (login --save / login --manual) is broken on recent");
         eprintln!("   KakaoTalk macOS builds. Do NOT repeatedly retry login on an unregistered");
         eprintln!("   device — it can get your account's sub-device login blocked. Prefer");
@@ -1296,6 +1361,37 @@ fn main() -> Result<()> {
                 json,
             })?
         }
+        Commands::SafeSend { action } => match action {
+            SafeSendAction::Propose {
+                chat_name,
+                message,
+                reply_chat_id,
+                reply_log_id,
+                idempotency_key,
+            } => {
+                let message = format_outgoing_message(&message, no_prefix);
+                commands::safe_send::cmd_propose(commands::safe_send::ProposeOptions {
+                    chat_name,
+                    message,
+                    reply_to: reply_chat_id.zip(reply_log_id),
+                    idempotency_key,
+                    json,
+                })?
+            }
+            SafeSendAction::List => commands::safe_send::cmd_list(json)?,
+            SafeSendAction::Approve { intent_id } => {
+                commands::safe_send::cmd_approve(commands::safe_send::ApproveOptions {
+                    intent_id,
+                    allow_ax_send: config.safety.allow_ax_send,
+                    allowed_chats: config.safety.allowed_send_chats.clone(),
+                    unattended,
+                    json,
+                })?
+            }
+            SafeSendAction::Cancel { intent_id, yes } => {
+                commands::safe_send::cmd_cancel(&intent_id, yes, json)?
+            }
+        },
         Commands::AxRead { chat_name, count } => {
             commands::ax_read::cmd_ax_read(commands::ax_read::AxReadOptions {
                 chat_name,
@@ -1334,6 +1430,8 @@ fn main() -> Result<()> {
         })?,
         Commands::NotifWatch {
             interval,
+            replay_existing,
+            durable,
             hook_cmd,
             webhook_url,
             webhook_header,
@@ -1344,6 +1442,8 @@ fn main() -> Result<()> {
             hook_fail_fast,
         } => commands::notif_watch::cmd_notif_watch(commands::notif_watch::NotifWatchOptions {
             interval_secs: interval,
+            replay_existing,
+            durable,
             hook_cmd,
             webhook_url,
             webhook_headers: webhook_header,
@@ -2448,6 +2548,39 @@ mod tests {
     }
 
     #[test]
+    fn safe_send_approve_command_parses_without_a_noninteractive_bypass() {
+        let cli = Cli::try_parse_from(["openkakao-cli", "safe-send", "approve", "intent-123"])
+            .expect("safe-send approve should parse");
+        match cli.command {
+            Commands::SafeSend {
+                action: SafeSendAction::Approve { intent_id },
+            } => assert_eq!(intent_id, "intent-123"),
+            other => panic!("expected safe-send approve, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn safe_send_cancel_command_parses() {
+        let cli = Cli::try_parse_from([
+            "openkakao-cli",
+            "safe-send",
+            "cancel",
+            "intent-123",
+            "--yes",
+        ])
+        .expect("safe-send cancel should parse");
+        match cli.command {
+            Commands::SafeSend {
+                action: SafeSendAction::Cancel { intent_id, yes },
+            } => {
+                assert_eq!(intent_id, "intent-123");
+                assert!(yes);
+            }
+            other => panic!("expected safe-send cancel, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn ax_watch_command_parses() {
         let cli = Cli::try_parse_from([
             "openkakao-cli",
@@ -2482,6 +2615,8 @@ mod tests {
             "notif-watch",
             "--interval",
             "5",
+            "--replay-existing",
+            "--durable",
             "--hook-keyword",
             "긴급",
             "--hook-chat",
@@ -2491,16 +2626,42 @@ mod tests {
         match cli.command {
             Commands::NotifWatch {
                 interval,
+                replay_existing,
+                durable,
                 hook_keyword,
                 hook_chat,
                 ..
             } => {
                 assert_eq!(interval, 5);
+                assert!(replay_existing);
+                assert!(durable);
                 assert_eq!(hook_keyword, vec!["긴급".to_string()]);
                 assert_eq!(hook_chat, vec!["정훈".to_string()]);
             }
             other => panic!("expected notif-watch, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn local_only_commands_skip_server_login_warning() {
+        for args in [
+            vec!["openkakao-cli", "notif-watch"],
+            vec!["openkakao-cli", "ax-watch"],
+            vec!["openkakao-cli", "ax-read", "room"],
+            vec!["openkakao-cli", "local-chats"],
+            vec!["openkakao-cli", "cache-stats"],
+            vec!["openkakao-cli", "doctor"],
+        ] {
+            let cli = Cli::try_parse_from(args).expect("local-only command should parse");
+            assert!(!should_warn_about_server_login(&cli.command));
+        }
+    }
+
+    #[test]
+    fn server_command_keeps_server_login_warning() {
+        let cli =
+            Cli::try_parse_from(["openkakao-cli", "chats"]).expect("server command should parse");
+        assert!(should_warn_about_server_login(&cli.command));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -564,6 +564,28 @@ enum Commands {
         #[arg(long)]
         hook_fail_fast: bool,
     },
+    /// Watch the macOS Notification Center DB for KakaoTalk messages
+    /// (login-free, works with the KakaoTalk window closed)
+    NotifWatch {
+        #[arg(long, default_value_t = 3)]
+        interval: u64,
+        #[arg(long)]
+        hook_cmd: Option<String>,
+        #[arg(long)]
+        webhook_url: Option<String>,
+        #[arg(long = "webhook-header")]
+        webhook_header: Vec<String>,
+        #[arg(long)]
+        webhook_signing_secret: Option<String>,
+        #[arg(long, default_value = "raw")]
+        webhook_format: String,
+        #[arg(long = "hook-chat")]
+        hook_chat: Vec<String>,
+        #[arg(long = "hook-keyword")]
+        hook_keyword: Vec<String>,
+        #[arg(long)]
+        hook_fail_fast: bool,
+    },
     /// Run diagnostic checks on KakaoTalk installation and connectivity
     Doctor {
         /// Also test LOCO booking connectivity (makes network request)
@@ -1292,6 +1314,35 @@ fn main() -> Result<()> {
             hook_keyword,
             hook_fail_fast,
         } => commands::ax_watch::cmd_ax_watch(commands::ax_watch::AxWatchOptions {
+            interval_secs: interval,
+            hook_cmd,
+            webhook_url,
+            webhook_headers: webhook_header,
+            webhook_signing_secret,
+            webhook_format: commands::watch::WebhookFormat::from_str_opt(Some(&webhook_format))?,
+            hook_chats: hook_chat,
+            hook_keywords: hook_keyword,
+            fail_fast: hook_fail_fast,
+            allow_insecure_webhooks: config.safety.allow_insecure_webhooks,
+            min_hook_interval_secs,
+            min_webhook_interval_secs,
+            hook_timeout_secs,
+            webhook_timeout_secs,
+            json,
+            unattended,
+            allow_side_effects: allow_watch_side_effects,
+        })?,
+        Commands::NotifWatch {
+            interval,
+            hook_cmd,
+            webhook_url,
+            webhook_header,
+            webhook_signing_secret,
+            webhook_format,
+            hook_chat,
+            hook_keyword,
+            hook_fail_fast,
+        } => commands::notif_watch::cmd_notif_watch(commands::notif_watch::NotifWatchOptions {
             interval_secs: interval,
             hook_cmd,
             webhook_url,
@@ -2421,6 +2472,34 @@ mod tests {
                 assert_eq!(hook_chat, vec!["정훈".to_string()]);
             }
             other => panic!("expected ax-watch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn notif_watch_command_parses() {
+        let cli = Cli::try_parse_from([
+            "openkakao-cli",
+            "notif-watch",
+            "--interval",
+            "5",
+            "--hook-keyword",
+            "긴급",
+            "--hook-chat",
+            "정훈",
+        ])
+        .expect("notif-watch should parse");
+        match cli.command {
+            Commands::NotifWatch {
+                interval,
+                hook_keyword,
+                hook_chat,
+                ..
+            } => {
+                assert_eq!(interval, 5);
+                assert_eq!(hook_keyword, vec!["긴급".to_string()]);
+                assert_eq!(hook_chat, vec!["정훈".to_string()]);
+            }
+            other => panic!("expected notif-watch, got {other:?}"),
         }
     }
 

--- a/src/receive_inbox.rs
+++ b/src/receive_inbox.rs
@@ -1,0 +1,347 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use rand::{Rng, RngCore};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::Serialize;
+use serde_json::Value;
+
+/// Result of atomically capturing an event by its stable idempotency key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CaptureResult {
+    Captured,
+    Duplicate,
+}
+
+/// One event awaiting delivery to configured watch sinks.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PendingEvent {
+    pub event_id: String,
+    pub source: String,
+    pub payload: Value,
+    pub attempts: u32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DeliveryClaim {
+    pub event: PendingEvent,
+    pub(crate) claim_token: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailureDisposition {
+    RetryScheduled { delay_secs: u64 },
+    Quarantined,
+}
+
+const MAX_DELIVERY_ATTEMPTS: u32 = 8;
+const RETRY_BASE_SECS: u64 = 5;
+const RETRY_CAP_SECS: u64 = 5 * 60;
+
+/// Durable local inbox for receive events.
+///
+/// Events are captured idempotently before external delivery. Callers consume
+/// pending events and acknowledge them through the same interface; SQLite
+/// schema, transactions, and retry bookkeeping stay inside the module.
+pub struct ReceiveInbox {
+    conn: Connection,
+}
+
+impl ReceiveInbox {
+    pub fn open() -> Result<Self> {
+        Self::open_at(&inbox_path()?)
+    }
+
+    pub fn open_at(path: &Path) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create receive inbox directory {}", parent.display()))?;
+        }
+        let conn = Connection::open(path)
+            .with_context(|| format!("open receive inbox {}", path.display()))?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+                .with_context(|| format!("secure receive inbox {}", path.display()))?;
+        }
+
+        conn.execute_batch(
+            "PRAGMA journal_mode = WAL;
+             PRAGMA busy_timeout = 5000;
+             CREATE TABLE IF NOT EXISTS receive_inbox (
+                 event_id     TEXT PRIMARY KEY,
+                 source       TEXT NOT NULL,
+                 payload      TEXT NOT NULL,
+                 state        TEXT NOT NULL DEFAULT 'pending'
+                              CHECK (state IN ('pending', 'delivering', 'delivered', 'quarantined')),
+                 captured_at  INTEGER NOT NULL,
+                 attempts     INTEGER NOT NULL DEFAULT 0,
+                 next_attempt_at INTEGER NOT NULL DEFAULT 0,
+                 claimed_at   INTEGER,
+                 lease_until  INTEGER,
+                 claim_token  TEXT,
+                 last_error   TEXT,
+                 delivered_at INTEGER
+             );
+             CREATE INDEX IF NOT EXISTS idx_receive_inbox_pending
+                 ON receive_inbox(state, next_attempt_at, captured_at, event_id);",
+        )?;
+        let now = chrono::Utc::now().timestamp();
+        conn.execute(
+            "UPDATE receive_inbox
+             SET state = 'pending', claimed_at = NULL, lease_until = NULL, claim_token = NULL,
+                 last_error = COALESCE(last_error, 'delivery lease expired after interruption')
+             WHERE state = 'delivering' AND (lease_until IS NULL OR lease_until <= ?1)",
+            [now],
+        )?;
+
+        Ok(Self { conn })
+    }
+
+    /// Persist an event once. Re-capturing the same id never rewrites its
+    /// payload or delivery state.
+    pub fn capture<T: Serialize>(
+        &self,
+        event_id: &str,
+        source: &str,
+        payload: &T,
+    ) -> Result<CaptureResult> {
+        let payload = serde_json::to_string(payload)?;
+        let inserted = self.conn.execute(
+            "INSERT OR IGNORE INTO receive_inbox
+             (event_id, source, payload, state, captured_at)
+             VALUES (?1, ?2, ?3, 'pending', ?4)",
+            params![event_id, source, payload, chrono::Utc::now().timestamp()],
+        )?;
+        Ok(if inserted == 1 {
+            CaptureResult::Captured
+        } else {
+            CaptureResult::Duplicate
+        })
+    }
+
+    /// Atomically claim the next ready event. Concurrent watcher processes
+    /// cannot receive the same claim; an interrupted claim is recovered after
+    /// a bounded lease on the next open/claim.
+    pub fn claim_next(&self, lease_secs: u64) -> Result<Option<DeliveryClaim>> {
+        let now = chrono::Utc::now().timestamp();
+        let lease_until = now.saturating_add(lease_secs.max(60).min(i64::MAX as u64) as i64);
+        let transaction = self.conn.unchecked_transaction()?;
+        transaction.execute(
+            "UPDATE receive_inbox
+             SET state = 'pending', claimed_at = NULL, lease_until = NULL, claim_token = NULL,
+                 last_error = COALESCE(last_error, 'delivery lease expired after interruption')
+             WHERE state = 'delivering' AND (lease_until IS NULL OR lease_until <= ?1)",
+            [now],
+        )?;
+        let row = transaction
+            .query_row(
+                "SELECT event_id, source, payload, attempts
+                 FROM receive_inbox
+                 WHERE state = 'pending' AND next_attempt_at <= ?1
+                 ORDER BY next_attempt_at, captured_at, event_id
+                 LIMIT 1",
+                [now],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, u32>(3)?,
+                    ))
+                },
+            )
+            .optional()?;
+
+        let Some((event_id, source, payload, attempts)) = row else {
+            transaction.commit()?;
+            return Ok(None);
+        };
+        let claim_token = random_claim_token();
+        let claimed = transaction.execute(
+            "UPDATE receive_inbox
+             SET state = 'delivering', claimed_at = ?2, lease_until = ?3, claim_token = ?4
+             WHERE event_id = ?1 AND state = 'pending' AND next_attempt_at <= ?2",
+            params![event_id, now, lease_until, claim_token],
+        )?;
+        if claimed != 1 {
+            anyhow::bail!("receive inbox claim changed concurrently");
+        }
+        transaction.commit()?;
+
+        match serde_json::from_str(&payload) {
+            Ok(payload) => Ok(Some(DeliveryClaim {
+                event: PendingEvent {
+                    event_id,
+                    source,
+                    payload,
+                    attempts,
+                },
+                claim_token,
+            })),
+            Err(error) => {
+                self.mark_claim_quarantined_parts(
+                    &event_id,
+                    &claim_token,
+                    &format!("invalid persisted JSON payload: {error}"),
+                )?;
+                Ok(None)
+            }
+        }
+    }
+
+    /// Acknowledge successful delivery. The event remains in the ledger so a
+    /// retained Notification Center record cannot be replayed after restart.
+    pub fn mark_delivered(&self, claim: &DeliveryClaim) -> Result<()> {
+        let changed = self.conn.execute(
+            "UPDATE receive_inbox
+             SET state = 'delivered', payload = 'null', delivered_at = ?3,
+                 claimed_at = NULL, lease_until = NULL, claim_token = NULL, last_error = NULL
+             WHERE event_id = ?1 AND state = 'delivering' AND claim_token = ?2",
+            params![
+                claim.event.event_id,
+                claim.claim_token,
+                chrono::Utc::now().timestamp()
+            ],
+        )?;
+        if changed != 1 {
+            anyhow::bail!("receive inbox delivery claim is stale; refusing acknowledgement");
+        }
+        Ok(())
+    }
+
+    /// Keep an event pending after an unsuccessful delivery and record enough
+    /// state for operators to see that retries are occurring.
+    pub fn mark_failed(&self, claim: &DeliveryClaim, error: &str) -> Result<FailureDisposition> {
+        let attempts: u32 = self.conn.query_row(
+            "SELECT attempts FROM receive_inbox
+             WHERE event_id = ?1 AND state = 'delivering' AND claim_token = ?2",
+            params![claim.event.event_id, claim.claim_token],
+            |row| row.get(0),
+        )?;
+        let attempts = attempts.saturating_add(1);
+        if attempts >= MAX_DELIVERY_ATTEMPTS {
+            let changed = self.conn.execute(
+                "UPDATE receive_inbox
+                 SET state = 'quarantined', attempts = ?3, claimed_at = NULL,
+                     lease_until = NULL, claim_token = NULL, last_error = ?4
+                 WHERE event_id = ?1 AND state = 'delivering' AND claim_token = ?2",
+                params![claim.event.event_id, claim.claim_token, attempts, error],
+            )?;
+            if changed != 1 {
+                anyhow::bail!("receive inbox delivery claim is stale; refusing quarantine");
+            }
+            return Ok(FailureDisposition::Quarantined);
+        }
+
+        let base_delay = retry_delay_secs(attempts);
+        let jitter = rand::thread_rng().gen_range(0..=base_delay / 4);
+        let delay_secs = base_delay.saturating_add(jitter);
+        let next_attempt_at = chrono::Utc::now()
+            .timestamp()
+            .saturating_add(delay_secs as i64);
+        let changed = self.conn.execute(
+            "UPDATE receive_inbox
+             SET state = 'pending', attempts = ?3, claimed_at = NULL,
+                 lease_until = NULL, claim_token = NULL,
+                 next_attempt_at = ?4, last_error = ?5
+             WHERE event_id = ?1 AND state = 'delivering' AND claim_token = ?2",
+            params![
+                claim.event.event_id,
+                claim.claim_token,
+                attempts,
+                next_attempt_at,
+                error
+            ],
+        )?;
+        if changed != 1 {
+            anyhow::bail!("receive inbox delivery claim is stale; refusing reschedule");
+        }
+        Ok(FailureDisposition::RetryScheduled { delay_secs })
+    }
+
+    /// Permanently remove a malformed event from the retry queue while
+    /// retaining its payload and diagnostic details for local inspection.
+    pub fn mark_claim_quarantined(&self, claim: &DeliveryClaim, error: &str) -> Result<()> {
+        self.mark_claim_quarantined_parts(&claim.event.event_id, &claim.claim_token, error)
+    }
+
+    fn mark_claim_quarantined_parts(
+        &self,
+        event_id: &str,
+        claim_token: &str,
+        error: &str,
+    ) -> Result<()> {
+        let changed = self.conn.execute(
+            "UPDATE receive_inbox
+             SET state = 'quarantined', attempts = attempts + 1,
+                 claimed_at = NULL, lease_until = NULL, claim_token = NULL, last_error = ?3
+             WHERE event_id = ?1 AND state = 'delivering' AND claim_token = ?2",
+            params![event_id, claim_token, error],
+        )?;
+        if changed != 1 {
+            anyhow::bail!("receive inbox delivery claim is stale; refusing quarantine");
+        }
+        Ok(())
+    }
+
+    /// Bound the durable ledger while preserving tombstones for notifications
+    /// still retained by Notification Center and a grace window for recently
+    /// removed records.
+    pub fn reconcile_terminal(
+        &self,
+        source: &str,
+        retained_event_ids: &HashSet<String>,
+        grace_secs: u64,
+    ) -> Result<usize> {
+        let cutoff = chrono::Utc::now()
+            .timestamp()
+            .saturating_sub(grace_secs.min(i64::MAX as u64) as i64);
+        let mut stmt = self.conn.prepare(
+            "SELECT event_id FROM receive_inbox
+             WHERE source = ?1 AND state IN ('delivered', 'quarantined') AND captured_at <= ?2",
+        )?;
+        let candidates = stmt
+            .query_map(params![source, cutoff], |row| row.get::<_, String>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        drop(stmt);
+
+        let transaction = self.conn.unchecked_transaction()?;
+        let mut deleted = 0;
+        for event_id in candidates {
+            if !retained_event_ids.contains(&event_id) {
+                deleted += transaction.execute(
+                    "DELETE FROM receive_inbox
+                     WHERE event_id = ?1 AND state IN ('delivered', 'quarantined')",
+                    [&event_id],
+                )?;
+            }
+        }
+        transaction.commit()?;
+        Ok(deleted)
+    }
+}
+
+fn retry_delay_secs(attempts: u32) -> u64 {
+    let exponent = attempts.saturating_sub(1).min(16);
+    RETRY_BASE_SECS
+        .saturating_mul(1_u64 << exponent)
+        .min(RETRY_CAP_SECS)
+}
+
+fn random_claim_token() -> String {
+    let mut bytes = [0_u8; 16];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    hex::encode(bytes)
+}
+
+fn inbox_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("resolve home directory for receive inbox")?;
+    Ok(home
+        .join(".config")
+        .join("openkakao")
+        .join("receive_inbox.db"))
+}

--- a/src/safe_send.rs
+++ b/src/safe_send.rs
@@ -1,0 +1,530 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use rand::RngCore;
+use rusqlite::{params, Connection, Transaction, TransactionBehavior};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Clone, Copy)]
+pub struct ProposeSend<'a> {
+    pub chat_name: &'a str,
+    pub message: &'a str,
+    pub reply_to: Option<(i64, i64)>,
+    pub idempotency_key: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SendState {
+    Proposed,
+    Sending,
+    Sent,
+    Uncertain,
+    Cancelled,
+    Expired,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SendIntent {
+    pub intent_id: String,
+    pub chat_name: String,
+    pub message: String,
+    pub reply_to: Option<(i64, i64)>,
+    pub state: SendState,
+    pub approval_code: String,
+    pub created_at: i64,
+    pub expires_at: i64,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SafeSendLimits {
+    pub min_interval_secs: u64,
+    pub max_per_chat_per_hour: u32,
+    pub max_global_per_hour: u32,
+    pub max_global_per_day: u32,
+    pub sending_lease_secs: u64,
+    pub proposal_ttl_secs: u64,
+}
+
+impl Default for SafeSendLimits {
+    fn default() -> Self {
+        Self {
+            min_interval_secs: 10,
+            max_per_chat_per_hour: 3,
+            max_global_per_hour: 10,
+            max_global_per_day: 20,
+            sending_lease_secs: 5 * 60,
+            proposal_ttl_secs: 15 * 60,
+        }
+    }
+}
+
+pub struct SafeSendOutbox {
+    conn: Connection,
+    limits: SafeSendLimits,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TransportOutcome {
+    /// A new message was observed in the exact target after commit.
+    Verified,
+    /// The transport failed before the commit action, so no message was sent.
+    NotSent { reason: String },
+    /// The commit action may have happened, but delivery could not be proven.
+    Uncertain { reason: String },
+}
+
+pub trait SendTransport {
+    fn send(&mut self, chat_name: &str, message: &str) -> TransportOutcome;
+}
+
+impl SafeSendOutbox {
+    pub fn open() -> Result<Self> {
+        Self::open_at(&outbox_path()?)
+    }
+
+    pub fn open_at(path: &Path) -> Result<Self> {
+        Self::open_at_with_limits(path, SafeSendLimits::default())
+    }
+
+    pub fn open_at_with_limits(path: &Path, limits: SafeSendLimits) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create safe-send directory {}", parent.display()))?;
+        }
+        let conn = Connection::open(path)
+            .with_context(|| format!("open safe-send outbox {}", path.display()))?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+                .with_context(|| format!("secure safe-send outbox {}", path.display()))?;
+        }
+
+        conn.execute_batch(
+            "PRAGMA journal_mode = WAL;
+             PRAGMA busy_timeout = 5000;
+             CREATE TABLE IF NOT EXISTS safe_send_outbox (
+                 intent_id        TEXT PRIMARY KEY,
+                 idempotency_key  TEXT NOT NULL UNIQUE,
+                 chat_name        TEXT NOT NULL,
+                 message          TEXT NOT NULL,
+                 reply_chat_id    INTEGER,
+                 reply_log_id     INTEGER,
+                 state            TEXT NOT NULL,
+                 nonce            TEXT NOT NULL,
+                 created_at       INTEGER NOT NULL,
+                 expires_at       INTEGER NOT NULL,
+                 claimed_at       INTEGER,
+                 last_error       TEXT,
+                 sent_at          INTEGER
+             );
+             CREATE INDEX IF NOT EXISTS idx_safe_send_outbox_state
+                 ON safe_send_outbox(state, created_at, intent_id);
+             CREATE INDEX IF NOT EXISTS idx_safe_send_outbox_claimed_at
+                 ON safe_send_outbox(claimed_at);
+             CREATE INDEX IF NOT EXISTS idx_safe_send_outbox_chat_claimed_at
+                 ON safe_send_outbox(chat_name, claimed_at);",
+        )?;
+        let stale_before = chrono::Utc::now()
+            .timestamp()
+            .saturating_sub(limits.sending_lease_secs.min(i64::MAX as u64) as i64);
+        conn.execute(
+            "UPDATE safe_send_outbox
+             SET state = 'uncertain',
+                 last_error = COALESCE(last_error, 'execution interrupted after send claim')
+             WHERE state = 'sending' AND (claimed_at IS NULL OR claimed_at <= ?1)",
+            [stale_before],
+        )?;
+        conn.execute(
+            "UPDATE safe_send_outbox
+             SET state = 'expired', last_error = 'approval window expired'
+             WHERE state = 'proposed' AND expires_at <= ?1",
+            [chrono::Utc::now().timestamp()],
+        )?;
+        Ok(Self { conn, limits })
+    }
+
+    pub fn propose(&self, request: ProposeSend<'_>) -> Result<SendIntent> {
+        if request.chat_name.trim().is_empty() {
+            anyhow::bail!("safe-send chat name must not be blank");
+        }
+        if request.message.trim().is_empty() {
+            anyhow::bail!("safe-send message must not be blank");
+        }
+        if request.chat_name.chars().any(is_display_spoofing_control) {
+            anyhow::bail!(
+                "safe-send chat name contains a control or bidirectional formatting character"
+            );
+        }
+        if request.message.chars().any(|character| {
+            is_display_spoofing_control(character) && !matches!(character, '\n' | '\t')
+        }) {
+            anyhow::bail!(
+                "safe-send message contains an unsafe control character or bidirectional formatting character"
+            );
+        }
+
+        let intent_id = random_hex(16);
+        let nonce = random_hex(16);
+        let idempotency_key = request
+            .idempotency_key
+            .map(str::to_owned)
+            .unwrap_or_else(|| format!("manual:{intent_id}"));
+        let created_at = chrono::Utc::now().timestamp();
+        let expires_at =
+            created_at.saturating_add(self.limits.proposal_ttl_secs.min(i64::MAX as u64) as i64);
+        let (reply_chat_id, reply_log_id) =
+            request.reply_to.map_or((None, None), |(chat_id, log_id)| {
+                (Some(chat_id), Some(log_id))
+            });
+
+        self.conn.execute(
+            "INSERT OR IGNORE INTO safe_send_outbox
+             (intent_id, idempotency_key, chat_name, message, reply_chat_id,
+              reply_log_id, state, nonce, created_at, expires_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'proposed', ?7, ?8, ?9)",
+            params![
+                intent_id,
+                idempotency_key,
+                request.chat_name,
+                request.message,
+                reply_chat_id,
+                reply_log_id,
+                nonce,
+                created_at,
+                expires_at,
+            ],
+        )?;
+
+        let stored = self.find_by_idempotency_key(&idempotency_key)?;
+        if stored.chat_name != request.chat_name
+            || stored.message != request.message
+            || stored.reply_to != request.reply_to
+        {
+            anyhow::bail!(
+                "safe-send idempotency key already belongs to different content: {}",
+                idempotency_key
+            );
+        }
+        Ok(stored)
+    }
+
+    pub fn list_active(&self) -> Result<Vec<SendIntent>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT intent_id, chat_name, message, reply_chat_id, reply_log_id,
+                    state, nonce, created_at, expires_at, last_error
+             FROM safe_send_outbox
+             WHERE state IN ('proposed', 'sending', 'uncertain')
+             ORDER BY created_at, intent_id",
+        )?;
+        let rows = stmt.query_map([], decode_intent_row)?;
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+
+    pub fn get(&self, intent_id: &str) -> Result<SendIntent> {
+        self.find_by_intent_id(intent_id)
+    }
+
+    pub fn approve_and_send(
+        &mut self,
+        intent_id: &str,
+        approval_code: &str,
+        transport: &mut impl SendTransport,
+    ) -> Result<SendIntent> {
+        let mut intent = self.find_by_intent_id(intent_id)?;
+        if intent.state != SendState::Proposed {
+            anyhow::bail!(
+                "safe-send intent {} is {}, not proposed",
+                intent_id,
+                state_name(intent.state)
+            );
+        }
+        if !constant_time_eq(approval_code.as_bytes(), intent.approval_code.as_bytes()) {
+            anyhow::bail!("safe-send approval code does not match the proposed content");
+        }
+        if chrono::Utc::now().timestamp() >= intent.expires_at {
+            self.conn.execute(
+                "UPDATE safe_send_outbox
+                 SET state = 'expired', last_error = 'approval window expired'
+                 WHERE intent_id = ?1 AND state = 'proposed'",
+                [intent_id],
+            )?;
+            anyhow::bail!("safe-send proposal has expired; create and review a new proposal");
+        }
+
+        let now = chrono::Utc::now().timestamp();
+        let transaction = self
+            .conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)?;
+        enforce_limits(&transaction, self.limits, &intent.chat_name, now)?;
+        let claimed = transaction.execute(
+            "UPDATE safe_send_outbox
+             SET state = 'sending', claimed_at = ?2
+             WHERE intent_id = ?1 AND state = 'proposed'",
+            params![intent_id, now],
+        )?;
+        if claimed != 1 {
+            anyhow::bail!("safe-send intent was already claimed; refusing a duplicate send");
+        }
+        transaction.commit()?;
+
+        match transport.send(&intent.chat_name, &intent.message) {
+            TransportOutcome::Verified => {}
+            TransportOutcome::NotSent { reason } => {
+                self.conn.execute(
+                    "UPDATE safe_send_outbox
+                     SET state = 'proposed', claimed_at = NULL, last_error = ?2
+                     WHERE intent_id = ?1 AND state = 'sending'",
+                    params![intent_id, reason],
+                )?;
+                anyhow::bail!(
+                    "safe-send message was not sent; the proposal remains available for review"
+                );
+            }
+            TransportOutcome::Uncertain { reason } => {
+                self.conn.execute(
+                    "UPDATE safe_send_outbox
+                     SET state = 'uncertain', last_error = ?2
+                     WHERE intent_id = ?1 AND state = 'sending'",
+                    params![intent_id, reason],
+                )?;
+                anyhow::bail!(
+                    "safe-send outcome is uncertain; inspect KakaoTalk and do not retry automatically"
+                );
+            }
+        }
+
+        let completed = self.conn.execute(
+            "UPDATE safe_send_outbox
+             SET state = 'sent', sent_at = ?2, last_error = NULL
+             WHERE intent_id = ?1 AND state = 'sending'",
+            params![intent_id, chrono::Utc::now().timestamp()],
+        )?;
+        if completed != 1 {
+            anyhow::bail!(
+                "safe-send completion state changed unexpectedly; inspect KakaoTalk before any new proposal"
+            );
+        }
+        intent.state = SendState::Sent;
+        Ok(intent)
+    }
+
+    pub fn cancel(&self, intent_id: &str) -> Result<SendIntent> {
+        let cancelled = self.conn.execute(
+            "UPDATE safe_send_outbox
+             SET state = 'cancelled',
+                 last_error = COALESCE(last_error, 'cancelled by operator')
+             WHERE intent_id = ?1 AND state IN ('proposed', 'uncertain')",
+            [intent_id],
+        )?;
+        if cancelled != 1 {
+            anyhow::bail!(
+                "safe-send intent is not cancellable; only proposed or uncertain intents can be cancelled"
+            );
+        }
+        self.find_by_intent_id(intent_id)
+    }
+
+    fn find_by_idempotency_key(&self, key: &str) -> Result<SendIntent> {
+        let intent = self.conn.query_row(
+            "SELECT intent_id, chat_name, message, reply_chat_id, reply_log_id,
+                    state, nonce, created_at, expires_at, last_error
+             FROM safe_send_outbox
+             WHERE idempotency_key = ?1",
+            [key],
+            decode_intent_row,
+        )?;
+        Ok(intent)
+    }
+
+    fn find_by_intent_id(&self, intent_id: &str) -> Result<SendIntent> {
+        let intent = self.conn.query_row(
+            "SELECT intent_id, chat_name, message, reply_chat_id, reply_log_id,
+                    state, nonce, created_at, expires_at, last_error
+             FROM safe_send_outbox
+             WHERE intent_id = ?1",
+            [intent_id],
+            decode_intent_row,
+        )?;
+        Ok(intent)
+    }
+}
+
+fn enforce_limits(
+    transaction: &Transaction<'_>,
+    limits: SafeSendLimits,
+    chat_name: &str,
+    now: i64,
+) -> Result<()> {
+    let last_claimed_at: Option<i64> = transaction.query_row(
+        "SELECT max(claimed_at) FROM safe_send_outbox WHERE claimed_at IS NOT NULL",
+        [],
+        |row| row.get(0),
+    )?;
+    if let Some(last_claimed_at) = last_claimed_at {
+        let available_at = last_claimed_at.saturating_add(limits.min_interval_secs as i64);
+        if now < available_at {
+            anyhow::bail!(
+                "safe-send global cooldown active for {}s",
+                available_at - now
+            );
+        }
+    }
+
+    let per_chat_hour: u32 = transaction.query_row(
+        "SELECT count(*) FROM safe_send_outbox
+         WHERE chat_name = ?1 AND claimed_at >= ?2",
+        params![chat_name, now - 60 * 60],
+        |row| row.get(0),
+    )?;
+    if per_chat_hour >= limits.max_per_chat_per_hour {
+        anyhow::bail!(
+            "safe-send per-chat hourly budget exhausted ({}/{})",
+            per_chat_hour,
+            limits.max_per_chat_per_hour
+        );
+    }
+
+    let global_hour: u32 = transaction.query_row(
+        "SELECT count(*) FROM safe_send_outbox WHERE claimed_at >= ?1",
+        [now - 60 * 60],
+        |row| row.get(0),
+    )?;
+    if global_hour >= limits.max_global_per_hour {
+        anyhow::bail!(
+            "safe-send global hourly budget exhausted ({}/{})",
+            global_hour,
+            limits.max_global_per_hour
+        );
+    }
+
+    let global_day: u32 = transaction.query_row(
+        "SELECT count(*) FROM safe_send_outbox WHERE claimed_at >= ?1",
+        [now - 24 * 60 * 60],
+        |row| row.get(0),
+    )?;
+    if global_day >= limits.max_global_per_day {
+        anyhow::bail!(
+            "safe-send global daily budget exhausted ({}/{})",
+            global_day,
+            limits.max_global_per_day
+        );
+    }
+    Ok(())
+}
+
+fn decode_intent_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SendIntent> {
+    let intent_id: String = row.get(0)?;
+    let chat_name: String = row.get(1)?;
+    let message: String = row.get(2)?;
+    let reply_chat_id: Option<i64> = row.get(3)?;
+    let reply_log_id: Option<i64> = row.get(4)?;
+    let state: String = row.get(5)?;
+    let nonce: String = row.get(6)?;
+    let created_at: i64 = row.get(7)?;
+    let expires_at: i64 = row.get(8)?;
+    let last_error: Option<String> = row.get(9)?;
+
+    let state = match state.as_str() {
+        "proposed" => SendState::Proposed,
+        "sending" => SendState::Sending,
+        "sent" => SendState::Sent,
+        "uncertain" => SendState::Uncertain,
+        "cancelled" => SendState::Cancelled,
+        "expired" => SendState::Expired,
+        other => {
+            return Err(rusqlite::Error::FromSqlConversionFailure(
+                5,
+                rusqlite::types::Type::Text,
+                format!("unknown safe-send state: {other}").into(),
+            ))
+        }
+    };
+    let reply_to = match (reply_chat_id, reply_log_id) {
+        (Some(chat_id), Some(log_id)) => Some((chat_id, log_id)),
+        _ => None,
+    };
+    let approval_code = approval_code(
+        &intent_id, &chat_name, &message, reply_to, created_at, expires_at, &nonce,
+    );
+
+    Ok(SendIntent {
+        intent_id,
+        chat_name,
+        message,
+        reply_to,
+        state,
+        approval_code,
+        created_at,
+        expires_at,
+        last_error,
+    })
+}
+
+fn state_name(state: SendState) -> &'static str {
+    match state {
+        SendState::Proposed => "proposed",
+        SendState::Sending => "sending",
+        SendState::Sent => "sent",
+        SendState::Uncertain => "uncertain",
+        SendState::Cancelled => "cancelled",
+        SendState::Expired => "expired",
+    }
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    left.iter()
+        .zip(right)
+        .fold(0_u8, |difference, (a, b)| difference | (a ^ b))
+        == 0
+}
+
+fn is_display_spoofing_control(character: char) -> bool {
+    character.is_control()
+        || matches!(
+            character,
+            '\u{061c}'
+                | '\u{200e}'
+                | '\u{200f}'
+                | '\u{202a}'..='\u{202e}'
+                | '\u{2066}'..='\u{2069}'
+        )
+}
+
+fn approval_code(
+    intent_id: &str,
+    chat_name: &str,
+    message: &str,
+    reply_to: Option<(i64, i64)>,
+    created_at: i64,
+    expires_at: i64,
+    nonce: &str,
+) -> String {
+    let canonical = serde_json::to_vec(&(
+        intent_id, chat_name, message, reply_to, created_at, expires_at, nonce,
+    ))
+    .expect("safe-send approval fields are serializable");
+    let digest = Sha256::digest(canonical);
+    hex::encode(digest)[..12].to_string()
+}
+
+fn random_hex(bytes: usize) -> String {
+    let mut value = vec![0_u8; bytes];
+    rand::thread_rng().fill_bytes(&mut value);
+    hex::encode(value)
+}
+
+fn outbox_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("resolve home directory for safe-send outbox")?;
+    Ok(home
+        .join(".config")
+        .join("openkakao")
+        .join("safe_send_outbox.db"))
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -181,6 +181,31 @@ pub fn truncate(s: &str, max_chars: usize) -> String {
     }
 }
 
+/// Escape characters that can forge terminal/log output while preserving
+/// ordinary Unicode text. Structured JSON and webhook payloads should keep the
+/// original value; this is only for human-readable terminal rendering.
+pub fn escape_terminal_text(value: &str) -> String {
+    value
+        .chars()
+        .flat_map(|character| {
+            if character.is_control()
+                || matches!(
+                    character,
+                    '\u{061c}'
+                        | '\u{200e}'
+                        | '\u{200f}'
+                        | '\u{202a}'..='\u{202e}'
+                        | '\u{2066}'..='\u{2069}'
+                )
+            {
+                character.escape_unicode().collect::<Vec<_>>()
+            } else {
+                vec![character]
+            }
+        })
+        .collect()
+}
+
 pub fn parse_since_date(since: Option<&str>) -> Result<Option<i64>> {
     let Some(s) = since else { return Ok(None) };
     let date = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d")
@@ -507,5 +532,13 @@ mod tests {
     #[test]
     fn test_mask_token_empty() {
         assert_eq!(mask_token(""), "");
+    }
+
+    #[test]
+    fn terminal_text_escapes_line_and_direction_controls() {
+        assert_eq!(
+            escape_terminal_text("정상\n위조\u{1b}[2J\u{202e}txt"),
+            "정상\\u{a}위조\\u{1b}[2J\\u{202e}txt"
+        );
     }
 }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -30,6 +30,7 @@ fn help_lists_expected_subcommands() {
         "members",
         "delete",
         "mark-read",
+        "safe-send",
     ] {
         assert!(
             stdout.contains(subcmd),
@@ -184,4 +185,60 @@ fn cache_stats_json_outputs_valid_json() {
         parsed["chats"].is_array(),
         "cache-stats --json 'chats' should be an array"
     );
+}
+
+#[test]
+fn safe_send_propose_and_list_are_local_only() {
+    let home = tempfile::tempdir().unwrap();
+    let output = cmd()
+        .env("HOME", home.path())
+        .args([
+            "--json",
+            "--no-prefix",
+            "safe-send",
+            "propose",
+            "허용된 방",
+            "검토할 답장",
+            "--reply-chat-id",
+            "42",
+            "--reply-log-id",
+            "99",
+            "--idempotency-key",
+            "reply:42:99:policy-v1",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "safe-send propose failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let proposed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(proposed["state"], "proposed");
+    assert_eq!(proposed["chat_name"], "허용된 방");
+    assert_eq!(proposed["message"], "검토할 답장");
+    assert_eq!(proposed["reply_to"], serde_json::json!([42, 99]));
+    assert_eq!(proposed["approval_code"].as_str().unwrap().len(), 12);
+
+    let listed = cmd()
+        .env("HOME", home.path())
+        .args(["--json", "safe-send", "list"])
+        .output()
+        .unwrap();
+    assert!(listed.status.success());
+    let active: serde_json::Value = serde_json::from_slice(&listed.stdout).unwrap();
+    assert_eq!(active.as_array().unwrap().len(), 1);
+    assert_eq!(active[0]["intent_id"], proposed["intent_id"]);
+
+    cmd()
+        .env("HOME", home.path())
+        .args([
+            "--unattended",
+            "safe-send",
+            "approve",
+            proposed["intent_id"].as_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("no unattended bypass"));
 }

--- a/tests/launchd_notif_watch_test.rs
+++ b/tests/launchd_notif_watch_test.rs
@@ -1,0 +1,45 @@
+use std::path::PathBuf;
+
+use plist::Value;
+
+fn example_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("examples")
+        .join("launchd")
+        .join(name)
+}
+
+#[test]
+fn launchagent_runs_the_durable_notification_receiver() {
+    let plist_path = example_path("com.openkakao.notif-watch.plist");
+    let plist = Value::from_file(&plist_path).expect("parse notif-watch LaunchAgent example");
+    let dict = plist.as_dictionary().expect("LaunchAgent root dictionary");
+
+    assert_eq!(
+        dict.get("Label").and_then(Value::as_string),
+        Some("com.openkakao.notif-watch")
+    );
+    assert_eq!(
+        dict.get("RunAtLoad").and_then(Value::as_boolean),
+        Some(true)
+    );
+    assert_eq!(
+        dict.get("KeepAlive").and_then(Value::as_boolean),
+        Some(true)
+    );
+
+    let arguments = dict
+        .get("ProgramArguments")
+        .and_then(Value::as_array)
+        .expect("ProgramArguments array");
+    assert_eq!(
+        arguments.first().and_then(Value::as_string),
+        Some("/Users/YOUR_USER/.config/openkakao/openkakao-notif-watch-wrapper.sh")
+    );
+
+    let wrapper = std::fs::read_to_string(example_path("openkakao-notif-watch-wrapper.sh"))
+        .expect("read notif-watch wrapper example");
+    assert!(wrapper.contains("notif-watch"));
+    assert!(wrapper.contains("--durable"));
+    assert!(!wrapper.contains("\n  watch"));
+}

--- a/tests/receive_inbox_test.rs
+++ b/tests/receive_inbox_test.rs
@@ -1,0 +1,257 @@
+use std::collections::HashSet;
+
+use openkakao_cli::receive_inbox::{CaptureResult, FailureDisposition, ReceiveInbox};
+use serde_json::json;
+
+#[test]
+fn captured_event_is_pending_and_duplicate_capture_is_idempotent() {
+    let dir = tempfile::tempdir().unwrap();
+    let inbox = ReceiveInbox::open_at(&dir.path().join("receive.db")).unwrap();
+    let payload = json!({
+        "event_type": "notif_message",
+        "chat_id": 42,
+        "log_id": 99,
+        "message": "hello"
+    });
+
+    assert_eq!(
+        inbox.capture("notif:42:99", "notif", &payload).unwrap(),
+        CaptureResult::Captured
+    );
+    assert_eq!(
+        inbox.capture("notif:42:99", "notif", &payload).unwrap(),
+        CaptureResult::Duplicate
+    );
+
+    let pending = inbox.claim_next(60).unwrap().unwrap().event;
+    assert_eq!(pending.event_id, "notif:42:99");
+    assert_eq!(pending.source, "notif");
+    assert_eq!(pending.payload, payload);
+    assert_eq!(pending.attempts, 0);
+}
+
+#[test]
+fn delivered_event_stays_acknowledged_after_reopen() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("receive.db");
+    let inbox = ReceiveInbox::open_at(&path).unwrap();
+    let payload = json!({"chat_id": 42, "log_id": 100});
+    inbox.capture("notif:42:100", "notif", &payload).unwrap();
+
+    let claim = inbox.claim_next(60).unwrap().unwrap();
+    assert_eq!(claim.event.event_id, "notif:42:100");
+    inbox.mark_delivered(&claim).unwrap();
+    assert!(inbox.claim_next(60).unwrap().is_none());
+    drop(inbox);
+
+    let reopened = ReceiveInbox::open_at(&path).unwrap();
+    assert!(reopened.claim_next(60).unwrap().is_none());
+    assert_eq!(
+        reopened.capture("notif:42:100", "notif", &payload).unwrap(),
+        CaptureResult::Duplicate
+    );
+}
+
+#[test]
+fn deferred_delivery_remains_pending_and_records_the_attempt() {
+    let dir = tempfile::tempdir().unwrap();
+    let inbox = ReceiveInbox::open_at(&dir.path().join("receive.db")).unwrap();
+    let payload = json!({"chat_id": 42, "log_id": 101});
+    inbox.capture("notif:42:101", "notif", &payload).unwrap();
+    let claim = inbox.claim_next(60).unwrap().unwrap();
+    assert_eq!(claim.event.event_id, "notif:42:101");
+
+    let disposition = inbox.mark_failed(&claim, "webhook unavailable").unwrap();
+    assert!(matches!(
+        disposition,
+        FailureDisposition::RetryScheduled { delay_secs } if delay_secs >= 5
+    ));
+
+    assert!(inbox.claim_next(60).unwrap().is_none());
+    drop(inbox);
+    let conn = rusqlite::Connection::open(dir.path().join("receive.db")).unwrap();
+    let attempts: u32 = conn
+        .query_row(
+            "SELECT attempts FROM receive_inbox WHERE event_id = ?1",
+            ["notif:42:101"],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(attempts, 1);
+}
+
+#[test]
+fn malformed_persisted_json_is_quarantined_without_blocking_later_events() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("receive.db");
+    let inbox = ReceiveInbox::open_at(&path).unwrap();
+    inbox
+        .capture("notif:42:broken", "notif", &json!({"message": "broken"}))
+        .unwrap();
+    inbox
+        .capture("notif:42:valid", "notif", &json!({"message": "valid"}))
+        .unwrap();
+    drop(inbox);
+
+    let conn = rusqlite::Connection::open(&path).unwrap();
+    conn.execute(
+        "UPDATE receive_inbox SET payload = 'not-json' WHERE event_id = ?1",
+        ["notif:42:broken"],
+    )
+    .unwrap();
+    drop(conn);
+
+    let inbox = ReceiveInbox::open_at(&path).unwrap();
+    assert!(inbox.claim_next(60).unwrap().is_none());
+    let pending = inbox.claim_next(60).unwrap().unwrap().event;
+    assert_eq!(pending.event_id, "notif:42:valid");
+    drop(inbox);
+
+    let conn = rusqlite::Connection::open(&path).unwrap();
+    let (state, attempts, error): (String, u32, String) = conn
+        .query_row(
+            "SELECT state, attempts, last_error FROM receive_inbox WHERE event_id = ?1",
+            ["notif:42:broken"],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(state, "quarantined");
+    assert_eq!(attempts, 1);
+    assert!(error.contains("invalid persisted JSON payload"));
+}
+
+#[test]
+fn delivery_claim_is_atomic_across_connections() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("receive.db");
+    let first = ReceiveInbox::open_at(&path).unwrap();
+    first
+        .capture("notif:42:claim", "notif", &json!({"message": "once"}))
+        .unwrap();
+    let second = ReceiveInbox::open_at(&path).unwrap();
+
+    assert_eq!(
+        first.claim_next(60).unwrap().unwrap().event.event_id,
+        "notif:42:claim"
+    );
+    assert!(second.claim_next(60).unwrap().is_none());
+}
+
+#[test]
+fn pending_claim_query_uses_covering_order_without_temp_sort() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("receive.db");
+    let _inbox = ReceiveInbox::open_at(&path).unwrap();
+    let conn = rusqlite::Connection::open(path).unwrap();
+
+    let mut stmt = conn
+        .prepare(
+            "EXPLAIN QUERY PLAN
+             SELECT event_id, source, payload, attempts
+             FROM receive_inbox
+             WHERE state = 'pending' AND next_attempt_at <= ?1
+             ORDER BY next_attempt_at, captured_at, event_id
+             LIMIT 1",
+        )
+        .unwrap();
+    let details = stmt
+        .query_map([chrono::Utc::now().timestamp()], |row| {
+            row.get::<_, String>(3)
+        })
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap()
+        .join("\n");
+
+    assert!(details.contains("idx_receive_inbox_pending"), "{details}");
+    assert!(!details.contains("TEMP B-TREE"), "{details}");
+}
+
+#[test]
+fn expired_claim_cannot_acknowledge_a_newer_claim() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("receive.db");
+    let first = ReceiveInbox::open_at(&path).unwrap();
+    first
+        .capture("notif:42:lease", "notif", &json!({"message": "once"}))
+        .unwrap();
+    let stale_claim = first.claim_next(60).unwrap().unwrap();
+
+    let conn = rusqlite::Connection::open(&path).unwrap();
+    conn.execute(
+        "UPDATE receive_inbox SET lease_until = 0 WHERE event_id = ?1",
+        ["notif:42:lease"],
+    )
+    .unwrap();
+    drop(conn);
+
+    let second = ReceiveInbox::open_at(&path).unwrap();
+    let current_claim = second.claim_next(60).unwrap().unwrap();
+    assert!(first.mark_delivered(&stale_claim).is_err());
+    second.mark_delivered(&current_claim).unwrap();
+}
+
+#[test]
+fn terminal_reconciliation_preserves_retained_ids_and_prunes_removed_ids() {
+    let dir = tempfile::tempdir().unwrap();
+    let inbox = ReceiveInbox::open_at(&dir.path().join("receive.db")).unwrap();
+    for id in ["notif:42:keep", "notif:42:prune"] {
+        inbox.capture(id, "notif", &json!({"message": id})).unwrap();
+        let claim = inbox.claim_next(60).unwrap().unwrap();
+        assert_eq!(claim.event.event_id, id);
+        inbox.mark_delivered(&claim).unwrap();
+    }
+
+    let retained = HashSet::from(["notif:42:keep".to_string()]);
+    assert_eq!(inbox.reconcile_terminal("notif", &retained, 0).unwrap(), 1);
+    assert_eq!(
+        inbox
+            .capture("notif:42:keep", "notif", &json!({"message": "duplicate"}))
+            .unwrap(),
+        CaptureResult::Duplicate
+    );
+    assert_eq!(
+        inbox
+            .capture("notif:42:prune", "notif", &json!({"message": "new again"}))
+            .unwrap(),
+        CaptureResult::Captured
+    );
+}
+
+#[test]
+fn repeated_failures_quarantine_poison_event_and_unblock_later_delivery() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("receive.db");
+    let inbox = ReceiveInbox::open_at(&path).unwrap();
+    inbox
+        .capture("notif:42:00-poison", "notif", &json!({"message": "poison"}))
+        .unwrap();
+    inbox
+        .capture("notif:42:99-later", "notif", &json!({"message": "later"}))
+        .unwrap();
+
+    for attempt in 1..=8 {
+        let claim = inbox.claim_next(60).unwrap().unwrap();
+        assert_eq!(claim.event.event_id, "notif:42:00-poison");
+        let disposition = inbox.mark_failed(&claim, "permanent failure").unwrap();
+        if attempt < 8 {
+            assert!(matches!(
+                disposition,
+                FailureDisposition::RetryScheduled { .. }
+            ));
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            conn.execute(
+                "UPDATE receive_inbox SET next_attempt_at = 0 WHERE event_id = ?1",
+                ["notif:42:00-poison"],
+            )
+            .unwrap();
+        } else {
+            assert_eq!(disposition, FailureDisposition::Quarantined);
+        }
+    }
+
+    assert_eq!(
+        inbox.claim_next(60).unwrap().unwrap().event.event_id,
+        "notif:42:99-later"
+    );
+}

--- a/tests/safe_send_outbox_test.rs
+++ b/tests/safe_send_outbox_test.rs
@@ -1,0 +1,547 @@
+use openkakao_cli::safe_send::{
+    ProposeSend, SafeSendLimits, SafeSendOutbox, SendIntent, SendState, SendTransport,
+    TransportOutcome,
+};
+
+#[derive(Default)]
+struct RecordingTransport {
+    sends: Vec<(String, String)>,
+}
+
+struct FailingTransport {
+    attempts: usize,
+}
+
+struct NotSentTransport {
+    attempts: usize,
+}
+
+struct PanickingTransport;
+
+impl SendTransport for PanickingTransport {
+    fn send(&mut self, _chat_name: &str, _message: &str) -> TransportOutcome {
+        panic!("simulated process interruption after send claim")
+    }
+}
+
+struct ConcurrentInspector {
+    path: std::path::PathBuf,
+    intent_id: String,
+    observed: Option<SendState>,
+}
+
+impl SendTransport for ConcurrentInspector {
+    fn send(&mut self, _chat_name: &str, _message: &str) -> TransportOutcome {
+        let observation =
+            SafeSendOutbox::open_at(&self.path).and_then(|observer| observer.get(&self.intent_id));
+        match observation {
+            Ok(intent) => {
+                self.observed = Some(intent.state);
+                TransportOutcome::Verified
+            }
+            Err(error) => TransportOutcome::NotSent {
+                reason: error.to_string(),
+            },
+        }
+    }
+}
+
+impl SendTransport for FailingTransport {
+    fn send(&mut self, _chat_name: &str, _message: &str) -> TransportOutcome {
+        self.attempts += 1;
+        TransportOutcome::Uncertain {
+            reason: "AX result is ambiguous".to_string(),
+        }
+    }
+}
+
+impl SendTransport for NotSentTransport {
+    fn send(&mut self, _chat_name: &str, _message: &str) -> TransportOutcome {
+        self.attempts += 1;
+        TransportOutcome::NotSent {
+            reason: "target window was not found before commit".to_string(),
+        }
+    }
+}
+
+impl SendTransport for RecordingTransport {
+    fn send(&mut self, chat_name: &str, message: &str) -> TransportOutcome {
+        self.sends
+            .push((chat_name.to_string(), message.to_string()));
+        TransportOutcome::Verified
+    }
+}
+
+fn propose_manual(outbox: &SafeSendOutbox, chat_name: &str, message: &str) -> SendIntent {
+    outbox
+        .propose(ProposeSend {
+            chat_name,
+            message,
+            reply_to: None,
+            idempotency_key: None,
+        })
+        .unwrap()
+}
+
+fn assert_second_global_send_is_blocked(limits: SafeSendLimits, expected_error: &str) {
+    let dir = tempfile::tempdir().unwrap();
+    let mut outbox =
+        SafeSendOutbox::open_at_with_limits(&dir.path().join("safe-send.db"), limits).unwrap();
+    let first = propose_manual(&outbox, "첫 번째 방", "첫 번째");
+    let second = propose_manual(&outbox, "두 번째 방", "두 번째");
+    let mut transport = RecordingTransport::default();
+
+    outbox
+        .approve_and_send(&first.intent_id, &first.approval_code, &mut transport)
+        .unwrap();
+    let error = outbox
+        .approve_and_send(&second.intent_id, &second.approval_code, &mut transport)
+        .unwrap_err();
+
+    assert!(
+        error.to_string().contains(expected_error),
+        "unexpected error: {error:#}"
+    );
+    assert_eq!(transport.sends.len(), 1);
+    assert_eq!(
+        outbox.get(&second.intent_id).unwrap().state,
+        SendState::Proposed
+    );
+}
+
+#[test]
+fn proposal_is_persisted_without_sending_and_deduplicated_by_source_event() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("safe-send.db");
+    let outbox = SafeSendOutbox::open_at(&path).unwrap();
+
+    let proposed = outbox
+        .propose(ProposeSend {
+            chat_name: "허용된 방",
+            message: "검토할 답장",
+            reply_to: Some((42, 99)),
+            idempotency_key: Some("reply:42:99:policy-v1"),
+        })
+        .unwrap();
+
+    assert_eq!(proposed.state, SendState::Proposed);
+    assert_eq!(proposed.chat_name, "허용된 방");
+    assert_eq!(proposed.message, "검토할 답장");
+    assert_eq!(proposed.reply_to, Some((42, 99)));
+    assert_eq!(proposed.approval_code.len(), 12);
+
+    let duplicate = outbox
+        .propose(ProposeSend {
+            chat_name: "허용된 방",
+            message: "검토할 답장",
+            reply_to: Some((42, 99)),
+            idempotency_key: Some("reply:42:99:policy-v1"),
+        })
+        .unwrap();
+    assert_eq!(duplicate.intent_id, proposed.intent_id);
+
+    drop(outbox);
+    let reopened = SafeSendOutbox::open_at(&path).unwrap();
+    assert_eq!(reopened.list_active().unwrap(), vec![proposed]);
+}
+
+#[test]
+fn idempotency_key_rejects_different_proposal_content() {
+    let dir = tempfile::tempdir().unwrap();
+    let outbox = SafeSendOutbox::open_at(&dir.path().join("safe-send.db")).unwrap();
+    let original = outbox
+        .propose(ProposeSend {
+            chat_name: "허용된 방",
+            message: "검토할 답장",
+            reply_to: Some((42, 99)),
+            idempotency_key: Some("reply:42:99:policy-v1"),
+        })
+        .unwrap();
+
+    for conflicting in [
+        ProposeSend {
+            chat_name: "다른 방",
+            message: "검토할 답장",
+            reply_to: Some((42, 99)),
+            idempotency_key: Some("reply:42:99:policy-v1"),
+        },
+        ProposeSend {
+            chat_name: "허용된 방",
+            message: "다른 답장",
+            reply_to: Some((42, 99)),
+            idempotency_key: Some("reply:42:99:policy-v1"),
+        },
+        ProposeSend {
+            chat_name: "허용된 방",
+            message: "검토할 답장",
+            reply_to: Some((42, 100)),
+            idempotency_key: Some("reply:42:99:policy-v1"),
+        },
+    ] {
+        let error = outbox.propose(conflicting).unwrap_err();
+        assert!(error.to_string().contains("different content"));
+    }
+
+    assert_eq!(outbox.list_active().unwrap(), vec![original]);
+}
+
+#[test]
+fn matching_approval_code_sends_exactly_once() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut outbox = SafeSendOutbox::open_at(&dir.path().join("safe-send.db")).unwrap();
+    let proposed = outbox
+        .propose(ProposeSend {
+            chat_name: "허용된 방",
+            message: "한 번만 전송",
+            reply_to: Some((42, 100)),
+            idempotency_key: Some("reply:42:100:policy-v1"),
+        })
+        .unwrap();
+    let mut transport = RecordingTransport::default();
+
+    let mut wrong_code = proposed.approval_code.clone().into_bytes();
+    wrong_code[0] = if wrong_code[0] == b'0' { b'1' } else { b'0' };
+    let wrong_code = String::from_utf8(wrong_code).unwrap();
+    assert!(outbox
+        .approve_and_send(&proposed.intent_id, &wrong_code, &mut transport)
+        .is_err());
+    assert!(transport.sends.is_empty());
+
+    let sent = outbox
+        .approve_and_send(&proposed.intent_id, &proposed.approval_code, &mut transport)
+        .unwrap();
+
+    assert_eq!(sent.state, SendState::Sent);
+    assert_eq!(
+        transport.sends,
+        vec![("허용된 방".to_string(), "한 번만 전송".to_string())]
+    );
+    assert!(outbox
+        .approve_and_send(&proposed.intent_id, &proposed.approval_code, &mut transport,)
+        .is_err());
+    assert_eq!(transport.sends.len(), 1);
+}
+
+#[test]
+fn ambiguous_transport_failure_is_quarantined_and_never_auto_retried() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("safe-send.db");
+    let mut outbox = SafeSendOutbox::open_at(&path).unwrap();
+    let proposed = outbox
+        .propose(ProposeSend {
+            chat_name: "허용된 방",
+            message: "중복되면 안 됨",
+            reply_to: Some((42, 101)),
+            idempotency_key: Some("reply:42:101:policy-v1"),
+        })
+        .unwrap();
+    let mut transport = FailingTransport { attempts: 0 };
+
+    assert!(outbox
+        .approve_and_send(&proposed.intent_id, &proposed.approval_code, &mut transport,)
+        .is_err());
+    assert_eq!(transport.attempts, 1);
+    drop(outbox);
+
+    let mut reopened = SafeSendOutbox::open_at(&path).unwrap();
+    let active = reopened.list_active().unwrap();
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0].state, SendState::Uncertain);
+    assert!(active[0]
+        .last_error
+        .as_deref()
+        .unwrap()
+        .contains("ambiguous"));
+    assert!(reopened
+        .approve_and_send(&proposed.intent_id, &proposed.approval_code, &mut transport,)
+        .is_err());
+    assert_eq!(transport.attempts, 1);
+}
+
+#[test]
+fn definitely_not_sent_returns_to_proposed_and_can_be_approved_again() {
+    let dir = tempfile::tempdir().unwrap();
+    let limits = SafeSendLimits {
+        min_interval_secs: 0,
+        ..SafeSendLimits::default()
+    };
+    let mut outbox =
+        SafeSendOutbox::open_at_with_limits(&dir.path().join("safe-send.db"), limits).unwrap();
+    let proposed = outbox
+        .propose(ProposeSend {
+            chat_name: "허용된 방",
+            message: "아직 전송되지 않음",
+            reply_to: None,
+            idempotency_key: None,
+        })
+        .unwrap();
+    let mut not_sent = NotSentTransport { attempts: 0 };
+
+    let error = outbox
+        .approve_and_send(&proposed.intent_id, &proposed.approval_code, &mut not_sent)
+        .unwrap_err();
+
+    assert!(error.to_string().contains("was not sent"));
+    assert_eq!(not_sent.attempts, 1);
+    let retryable = outbox.get(&proposed.intent_id).unwrap();
+    assert_eq!(retryable.state, SendState::Proposed);
+    assert!(retryable
+        .last_error
+        .as_deref()
+        .unwrap()
+        .contains("target window"));
+
+    let mut verified = RecordingTransport::default();
+    let sent = outbox
+        .approve_and_send(&proposed.intent_id, &proposed.approval_code, &mut verified)
+        .unwrap();
+    assert_eq!(sent.state, SendState::Sent);
+    assert_eq!(verified.sends.len(), 1);
+}
+
+#[test]
+fn interrupted_execution_becomes_uncertain_when_the_outbox_reopens() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("safe-send.db");
+    let limits = SafeSendLimits {
+        sending_lease_secs: 0,
+        ..SafeSendLimits::default()
+    };
+    let mut outbox = SafeSendOutbox::open_at_with_limits(&path, limits).unwrap();
+    let proposed = outbox
+        .propose(ProposeSend {
+            chat_name: "허용된 방",
+            message: "중단 테스트",
+            reply_to: Some((42, 102)),
+            idempotency_key: Some("reply:42:102:policy-v1"),
+        })
+        .unwrap();
+
+    let interrupted = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _ = outbox.approve_and_send(
+            &proposed.intent_id,
+            &proposed.approval_code,
+            &mut PanickingTransport,
+        );
+    }));
+    assert!(interrupted.is_err());
+    drop(outbox);
+
+    let reopened = SafeSendOutbox::open_at_with_limits(&path, limits).unwrap();
+    let active = reopened.list_active().unwrap();
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0].state, SendState::Uncertain);
+    assert!(active[0]
+        .last_error
+        .as_deref()
+        .unwrap()
+        .contains("interrupted"));
+}
+
+#[test]
+fn cancelled_proposal_can_never_be_sent() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut outbox = SafeSendOutbox::open_at(&dir.path().join("safe-send.db")).unwrap();
+    let proposed = outbox
+        .propose(ProposeSend {
+            chat_name: "허용된 방",
+            message: "취소할 메시지",
+            reply_to: None,
+            idempotency_key: None,
+        })
+        .unwrap();
+    let mut transport = RecordingTransport::default();
+
+    let cancelled = outbox.cancel(&proposed.intent_id).unwrap();
+
+    assert_eq!(cancelled.state, SendState::Cancelled);
+    assert!(outbox.list_active().unwrap().is_empty());
+    assert!(outbox
+        .approve_and_send(&proposed.intent_id, &proposed.approval_code, &mut transport,)
+        .is_err());
+    assert!(transport.sends.is_empty());
+}
+
+#[test]
+fn configured_send_budget_refuses_excess_messages_before_transport() {
+    let dir = tempfile::tempdir().unwrap();
+    let limits = SafeSendLimits {
+        min_interval_secs: 0,
+        max_per_chat_per_hour: 1,
+        max_global_per_hour: 10,
+        max_global_per_day: 10,
+        sending_lease_secs: 5 * 60,
+        proposal_ttl_secs: 15 * 60,
+    };
+    let mut outbox =
+        SafeSendOutbox::open_at_with_limits(&dir.path().join("safe-send.db"), limits).unwrap();
+    let first = outbox
+        .propose(ProposeSend {
+            chat_name: "허용된 방",
+            message: "첫 번째",
+            reply_to: None,
+            idempotency_key: None,
+        })
+        .unwrap();
+    let second = outbox
+        .propose(ProposeSend {
+            chat_name: "허용된 방",
+            message: "두 번째",
+            reply_to: None,
+            idempotency_key: None,
+        })
+        .unwrap();
+    let mut transport = RecordingTransport::default();
+    outbox
+        .approve_and_send(&first.intent_id, &first.approval_code, &mut transport)
+        .unwrap();
+
+    let error = outbox
+        .approve_and_send(&second.intent_id, &second.approval_code, &mut transport)
+        .unwrap_err();
+
+    assert!(error.to_string().contains("per-chat hourly budget"));
+    assert_eq!(transport.sends.len(), 1);
+    assert_eq!(outbox.list_active().unwrap(), vec![second]);
+}
+
+#[test]
+fn global_cooldown_refuses_a_second_send_before_transport() {
+    assert_second_global_send_is_blocked(
+        SafeSendLimits {
+            min_interval_secs: 60,
+            ..SafeSendLimits::default()
+        },
+        "global cooldown",
+    );
+}
+
+#[test]
+fn global_hourly_budget_refuses_a_second_send_before_transport() {
+    assert_second_global_send_is_blocked(
+        SafeSendLimits {
+            min_interval_secs: 0,
+            max_per_chat_per_hour: 10,
+            max_global_per_hour: 1,
+            max_global_per_day: 10,
+            ..SafeSendLimits::default()
+        },
+        "global hourly budget",
+    );
+}
+
+#[test]
+fn global_daily_budget_refuses_a_second_send_before_transport() {
+    assert_second_global_send_is_blocked(
+        SafeSendLimits {
+            min_interval_secs: 0,
+            max_per_chat_per_hour: 10,
+            max_global_per_hour: 10,
+            max_global_per_day: 1,
+            ..SafeSendLimits::default()
+        },
+        "global daily budget",
+    );
+}
+
+#[test]
+fn concurrent_inspection_does_not_quarantine_an_in_flight_send() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("safe-send.db");
+    let mut outbox = SafeSendOutbox::open_at(&path).unwrap();
+    let proposed = outbox
+        .propose(ProposeSend {
+            chat_name: "허용된 방",
+            message: "진행 중 관찰",
+            reply_to: None,
+            idempotency_key: None,
+        })
+        .unwrap();
+    let mut transport = ConcurrentInspector {
+        path: path.clone(),
+        intent_id: proposed.intent_id.clone(),
+        observed: None,
+    };
+
+    outbox
+        .approve_and_send(&proposed.intent_id, &proposed.approval_code, &mut transport)
+        .unwrap();
+
+    assert_eq!(transport.observed, Some(SendState::Sending));
+    assert_eq!(
+        outbox.get(&proposed.intent_id).unwrap().state,
+        SendState::Sent
+    );
+}
+
+#[test]
+fn proposal_rejects_terminal_control_sequences() {
+    let dir = tempfile::tempdir().unwrap();
+    let outbox = SafeSendOutbox::open_at(&dir.path().join("safe-send.db")).unwrap();
+
+    let error = outbox
+        .propose(ProposeSend {
+            chat_name: "허용된 방",
+            message: "정상처럼 보임\u{1b}[2J위조된 승인 화면",
+            reply_to: None,
+            idempotency_key: None,
+        })
+        .unwrap_err();
+
+    assert!(error.to_string().contains("control character"));
+    assert!(outbox.list_active().unwrap().is_empty());
+}
+
+#[test]
+fn proposal_rejects_bidirectional_display_spoofing() {
+    let dir = tempfile::tempdir().unwrap();
+    let outbox = SafeSendOutbox::open_at(&dir.path().join("safe-send.db")).unwrap();
+
+    for dangerous in [
+        '\u{061c}', '\u{200e}', '\u{200f}', '\u{202e}', '\u{2066}', '\u{2069}',
+    ] {
+        let message = format!("review {dangerous}spoofed");
+        let error = outbox
+            .propose(ProposeSend {
+                chat_name: "허용된 방",
+                message: &message,
+                reply_to: None,
+                idempotency_key: None,
+            })
+            .unwrap_err();
+        assert!(error.to_string().contains("bidirectional"));
+    }
+    assert!(outbox.list_active().unwrap().is_empty());
+}
+
+#[test]
+fn expired_proposal_is_never_claimed_for_transport() {
+    let dir = tempfile::tempdir().unwrap();
+    let limits = SafeSendLimits {
+        proposal_ttl_secs: 0,
+        ..SafeSendLimits::default()
+    };
+    let mut outbox =
+        SafeSendOutbox::open_at_with_limits(&dir.path().join("safe-send.db"), limits).unwrap();
+    let proposed = outbox
+        .propose(ProposeSend {
+            chat_name: "허용된 방",
+            message: "이미 만료",
+            reply_to: None,
+            idempotency_key: None,
+        })
+        .unwrap();
+    let mut transport = RecordingTransport::default();
+
+    let error = outbox
+        .approve_and_send(&proposed.intent_id, &proposed.approval_code, &mut transport)
+        .unwrap_err();
+
+    assert!(error.to_string().contains("expired"));
+    assert!(transport.sends.is_empty());
+    assert!(outbox.list_active().unwrap().is_empty());
+    assert_eq!(
+        outbox.get(&proposed.intent_id).unwrap().state,
+        SendState::Expired
+    );
+}

--- a/website/content/docs/cli/diagnostics.mdx
+++ b/website/content/docs/cli/diagnostics.mdx
@@ -24,6 +24,7 @@ Checks performed:
 - REST API token validity
 - LOCO booking connectivity (with `--loco`)
 - Local DB (SQLCipher) access — UUID, userId, file, decryption
+- Notification Center DB access, KakaoTalk registration, and `notif-watch` schema compatibility
 - LOCO write operations status (enabled/disabled)
 - persisted auth recovery state
 - current safety guard policy and recent guard hits

--- a/website/content/docs/cli/local-send.mdx
+++ b/website/content/docs/cli/local-send.mdx
@@ -18,6 +18,7 @@ Both commands find the target chat by its **exact display name**, the same text 
 Requirements:
 - KakaoTalk.app installed, running, and already logged in on this Mac
 - Accessibility permission granted to your terminal (System Settings → Privacy & Security → Accessibility)
+- Touch ID or the macOS login password available for device-owner authentication before a real send
 
 ## local-send
 
@@ -39,7 +40,9 @@ openkakao-cli local-send "chat display name" "Hello from CLI!" --dry-run
 openkakao-cli local-send "chat display name" "Hello from CLI!" -y
 ```
 
-After typing the message and pressing Enter, `local-send` polls the chat window's own message list (scraped via AX, the same mechanism as `ax-read`) to confirm the message actually appeared, instead of trusting a fixed sleep.
+Before typing, `local-send` verifies the running process has KakaoTalk's official bundle/team code signature, requires one unique exact-name row in the chat list and an empty composer, and asks macOS to authenticate the device owner. It then reads the selected row and exact composer value back immediately before pressing Enter. After Enter may have been delivered, it polls the target window and reports success only when the composer clears and an additional exact-text outgoing message bubble appears. An old or incoming identical bubble is not accepted as proof of a new send.
+
+This is a native macOS Accessibility/CoreGraphics path inside `openkakao-cli`; Orca and agent `$computer-use` skills are not runtime dependencies.
 
 ## ax-read
 
@@ -72,7 +75,9 @@ allowed_send_chats = ["chat display name you want to allow"]
 ```
 
 - `allow_ax_send` — the general opt-in, since `local-send` types text and hits Enter in a real KakaoTalk window on your behalf.
-- `allowed_send_chats` — an **exact-match allowlist**. Because there is no chat-id to verify the send target against, this is the only guard against a typo or a display-name collision sending to the wrong chat. A chat not on this list is rejected before anything is typed.
+- `allowed_send_chats` — an **exact-match allowlist**. A chat not on this list is rejected before anything is typed. At runtime, a duplicate exact display name is also refused, and the selected row is read back before Enter.
+
+Real sends also require macOS device-owner authentication. `-y` skips only the CLI's ordinary confirmation prompt; it does not bypass Touch ID/login-password authentication.
 
 Both checks are skipped for `--dry-run`, so you can preview against any chat name without touching config.
 

--- a/website/content/docs/cli/overview.mdx
+++ b/website/content/docs/cli/overview.mdx
@@ -85,7 +85,10 @@ Persistent policy can be stored in [Configuration](/docs/getting-started/configu
 | Command | Description |
 |---------|-------------|
 | `local-send <chat_name> <msg>` | Send a real message by driving the KakaoTalk UI directly (requires `allow_ax_send` + `allowed_send_chats`, supports `--dry-run`) |
+| `safe-send propose/list/approve/cancel` | Persist an AX send proposal for human review; approval requires an interactive terminal, the proposal code, and macOS device-owner authentication |
 | `ax-read <chat_name>` | Read the most recently visible messages in a chat via the same UI-scraping mechanism |
+| `ax-watch` | Poll the visible chat list for unread-count increases and dispatch hooks/webhooks |
+| `notif-watch` | Read KakaoTalk notifications from Notification Center without a Kakao server session or visible KakaoTalk window |
 
 ### Local Database (currently unreliable)
 | Command | Description |

--- a/website/content/docs/getting-started/configuration.mdx
+++ b/website/content/docs/getting-started/configuration.mdx
@@ -69,6 +69,8 @@ hook_timeout_secs = 20
 webhook_timeout_secs = 10
 allow_insecure_webhooks = false
 allow_loco_write = false
+allow_ax_send = false
+allowed_send_chats = []
 ```
 
 ## Current Fields
@@ -90,6 +92,8 @@ allow_loco_write = false
 | `safety.webhook_timeout_secs` | int | HTTP timeout for webhook delivery |
 | `safety.allow_insecure_webhooks` | bool | allow non-HTTPS webhooks outside localhost |
 | `safety.allow_loco_write` | bool | enable LOCO write operations (send, delete, edit, react) — disabled by default for account safety |
+| `safety.allow_ax_send` | bool | enable real AX sends through `local-send` or human-approved `safe-send` — disabled by default |
+| `safety.allowed_send_chats` | string array | exact KakaoTalk display names that real AX sends may target; an empty list denies every target |
 
 ## High-Value Sections
 

--- a/website/content/docs/getting-started/installation.mdx
+++ b/website/content/docs/getting-started/installation.mdx
@@ -20,11 +20,11 @@ brew update && brew upgrade openkakao-cli
 
 ## Build from source
 
-Requires Rust `>= 1.75`.
+The repository pins Rust `1.95.0` in `rust-toolchain.toml`; `rustup` selects it automatically.
 
 ```bash
 git clone https://github.com/JungHoonGhae/openkakao-cli.git
-cd openkakao/openkakao-cli
+cd openkakao-cli
 cargo install --path .
 ```
 


### PR DESCRIPTION
## Summary

**Agent-safe native sending**

- Adds `safe-send propose/list/approve/cancel`, backed by a crash-safe local SQLite outbox with content-bound approval codes, expiry, exact chat allowlists, conservative rate budgets, and uncertain-delivery quarantine.
- Requires an interactive terminal and macOS device-owner authentication immediately before a real AX send. The running KakaoTalk process is PID-bound and validated against its Apple code signature; unattended approval has no bypass.
- Hardens direct `local-send` with exact-target selection, bounded Accessibility traversal, pre-send composer revalidation, and exact outgoing-message delivery verification.

**Durable local receiving**

- Adds Notification Center-backed `notif-watch`, including replay, durable SQLite persistence, atomic leases, deduplication across restarts, bounded retries with jitter, quarantine, tombstone pruning, and schema diagnostics.
- Extracts shared hook/webhook dispatch, rejects webhook redirects, propagates hook stdin failures, and escapes terminal/bidirectional control characters.
- Adds a supervised `launchd` example and expands `doctor` with Notification Center access and schema checks.

**Safety, portability, and documentation**

- Keeps LOCO writes disabled by default and documents the preview-first, human-approved agent workflow in Korean and English.
- Extends CI coverage to native Objective-C/build inputs, keeps macOS-only APIs lint-clean on Linux, and replaces notification identifiers in tests with synthetic fixtures.
- Updates the CLI site, source-install instructions, configuration reference, research notes, roadmap, and release notes for v1.8.0.

## Test Coverage

All new safety, durable-delivery, retry, quarantine, schema, redirection, terminal-sanitization, and native-send verification paths have automated coverage.

- 372 Rust tests passed with `cargo test --all-features`
- Branch-path coverage audit estimate: 80%
- Documentation type check and static production build passed for all 114 generated pages

## Pre-Landing Review

Independent security, adversarial, and performance reviews all returned **SHIP** with no remaining material bypasses or merge blockers. Two Linux-only dead-code lint findings from branch CI were fixed before PR creation.

## Design Review

No frontend implementation files changed; design review skipped.

## Eval Results

No prompt-related files changed; evals skipped.

## Scope Drift

Scope Check: CLEAN. Changes stay within agent-safe native send, durable local receive, diagnostics, tests, release automation, and their documentation.

## Plan Completion

No plan file detected.

## Verification Results

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` (372 passed, 0 failed)
- [x] `cargo build --release`
- [x] `cargo package`
- [x] LaunchAgent plist and wrapper syntax checks
- [x] Release binary reports `openkakao-cli 1.8.0`

## Documentation

### Updated

- `README.md` / `README.en.md`: corrected the source-install directory and aligned the Rust requirement and badge with the pinned 1.95.0 toolchain.
- `CONTRIBUTING.md`: corrected the new-contributor clone workflow.
- `website/content/docs/cli/overview.mdx`: added `safe-send`, `ax-watch`, and `notif-watch` to the command reference.
- `website/content/docs/getting-started/configuration.mdx`: documented `allow_ax_send` and `allowed_send_chats`.
- `website/content/docs/cli/diagnostics.mdx`: documented Notification Center access and schema checks.
- `website/content/docs/getting-started/installation.mdx`: aligned source installation with the repository layout and pinned toolchain.
- `docs/research/local-receive-strategy.md`: repaired source line references after implementation growth.

Validation: the Fumadocs/Next.js type check and static production build passed for all 114 generated pages.

### Documentation Debt

- Critical gaps: none. The new public surfaces have repository-level reference and how-to coverage.
- Common gaps: `safe-send` has no dedicated documentation-site tutorial yet; README and AGENTS provide the current operational workflow.
- Stale diagrams: `website/content/docs/index.mdx` models REST/LOCO but does not yet show the native AX send and Notification Center receive paths.
- Historical debt: `docs/IMPROVEMENT_PLAN.md` contains stale pre-1.0 narrative and is not discoverable from a primary entry point.

Consider adding the `docs-debt` label for the deferred narrative and diagram work.

## Test plan

- [x] GitHub Linux tests pass or are re-run on this final PR head
- [x] GitHub Linux lint passes or is re-run on this final PR head
- [x] GitHub macOS release build and smoke test pass or are re-run on this final PR head
- [x] No real KakaoTalk message was sent during verification

🤖 Generated with Codex
