### PR TITLE
fix(local-db): recover saved user ID on KakaoTalk 26.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- KakaoTalk 26.7.0 replaced the numeric `FSChatWindowFrame_` preference suffixes with opaque hashes, so userId recovery on that build fell through to the bounded SHA-512 brute force. A locally saved user ID (from `login --save`) is now reused — before the brute force, so large IDs no longer risk exhausting the search budget — but only when its SHA-512 exactly matches the plist's non-zero active-account marker; stale or inactive credentials are rejected and the existing direct-key and brute-force fallbacks are unchanged. This does not fix the separately broken SQLCipher key derivation on recent builds.
+
 ## [1.8.0] - 2026-09-02
 
 ### Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod credentials;
 pub mod error;
 pub mod human_auth;
 pub mod local_db;

--- a/src/local_db.rs
+++ b/src/local_db.rs
@@ -73,7 +73,8 @@ fn get_user_id_from_plist() -> Result<i64> {
             for entry in entries.flatten() {
                 let name = entry.file_name().to_string_lossy().to_string();
                 if name.starts_with("com.kakao.KakaoTalkMac.") && name.ends_with(".plist") {
-                    if let Ok(user_id) = extract_user_id_from_plist(&entry.path()) {
+                    let path = entry.path();
+                    if let Ok(user_id) = extract_user_id_from_plist(&path) {
                         return Ok(user_id);
                     }
                 }
@@ -93,6 +94,11 @@ fn get_user_id_from_plist() -> Result<i64> {
         "Could not extract KakaoTalk user ID from preferences. \
          Is KakaoTalk installed and logged in?"
     )
+}
+
+fn dict_has_active_user_id(dict: &plist::Dictionary, user_id: i64) -> bool {
+    let expected = hex::encode(sha2::Sha512::digest(user_id.to_string().as_bytes()));
+    extract_active_account_hash(dict).as_deref() == Some(expected.as_str())
 }
 
 fn extract_user_id_from_plist(path: &std::path::Path) -> Result<i64> {
@@ -145,7 +151,17 @@ fn extract_user_id_from_plist(path: &std::path::Path) -> Result<i64> {
         return Ok(id);
     }
 
-    // Strategy D: SHA-512 brute-force from revision key suffixes (last resort).
+    // Strategy D: KakaoTalk 26.7 uses opaque FSChatWindowFrame_* suffixes.
+    // Reuse a previously saved user ID only when it hashes to this plist's
+    // active-account marker. Run this before brute force so larger IDs do not
+    // exhaust the bounded search first.
+    if let Ok(Some(credentials)) = crate::credentials::load_credentials() {
+        if credentials.user_id > 0 && dict_has_active_user_id(&dict, credentials.user_id) {
+            return Ok(credentials.user_id);
+        }
+    }
+
+    // Strategy E: SHA-512 brute-force from revision key suffixes (last resort).
     // Bounded by a wall-clock deadline so a missing/foreign hash cannot hang the CLI.
     if let Some(hash) = extract_active_account_hash(&dict) {
         if let Some(id) = recover_user_id_from_sha512(&hash) {
@@ -725,5 +741,32 @@ mod tests {
     #[test]
     fn sha512_recovery_rejects_malformed_hash() {
         assert_eq!(recover_user_id_from_sha512("not-a-hash"), None);
+    }
+
+    #[test]
+    fn saved_user_id_must_match_active_account_hash() {
+        let user_id = 199453377;
+        let hash = hex::encode(sha2::Sha512::digest(user_id.to_string().as_bytes()));
+        let mut dict = plist::Dictionary::new();
+        dict.insert(
+            format!("DESIGNATEDFRIENDSREVISION:{hash}"),
+            plist::Value::Integer(1.into()),
+        );
+
+        assert!(dict_has_active_user_id(&dict, user_id));
+        assert!(!dict_has_active_user_id(&dict, user_id + 1));
+    }
+
+    #[test]
+    fn saved_user_id_rejects_inactive_account_hash() {
+        let user_id = 199453377;
+        let hash = hex::encode(sha2::Sha512::digest(user_id.to_string().as_bytes()));
+        let mut dict = plist::Dictionary::new();
+        dict.insert(
+            format!("DESIGNATEDFRIENDSREVISION:{hash}"),
+            plist::Value::Integer(0.into()),
+        );
+
+        assert!(!dict_has_active_user_id(&dict, user_id));
     }
 }

--- a/tests/local_db_user_id_test.rs
+++ b/tests/local_db_user_id_test.rs
@@ -1,0 +1,197 @@
+//! End-to-end recovery of the active KakaoTalk user ID from 26.7-style
+//! preferences, driven through the public `LocalDbReader::check_access()` —
+//! the same entry point behind `openkakao-cli doctor`'s "Local DB (SQLCipher)"
+//! check and every `local` read command.
+//!
+//! KakaoTalk 26.7.0 replaced the numeric `FSChatWindowFrame_` preference
+//! suffixes with opaque hashes, so the plist only identifies the active
+//! account through its `DESIGNATEDFRIENDSREVISION:<sha512(userId)>` marker.
+//! These tests build a simulated KakaoTalk home (binary plist + saved
+//! credentials from `login --save`) and observe whether user-ID recovery
+//! succeeds, without touching any real KakaoTalk data or sending anything.
+
+use std::fs;
+use std::path::Path;
+use std::sync::Mutex;
+use std::time::Instant;
+
+use openkakao_cli::local_db::{LocalDbReader, LocalDbStatus};
+use sha2::Digest;
+
+/// `dirs::home_dir()` reads $HOME, and the tests share one process.
+static HOME_LOCK: Mutex<()> = Mutex::new(());
+
+fn sha512_hex(value: &str) -> String {
+    hex::encode(sha2::Sha512::digest(value.as_bytes()))
+}
+
+/// Write a KakaoTalk 26.7-style container preference plist: opaque (non-numeric)
+/// `FSChatWindowFrame_` suffixes, an optional `DESIGNATEDFRIENDSREVISION:<sha512>`
+/// active-account marker, and an optional legacy direct `KAKAO_USER_ID` key.
+fn write_kt267_plist(
+    home: &Path,
+    marker_id: Option<i64>,
+    marker_value: i64,
+    direct_user_id: Option<i64>,
+) {
+    let prefs = home.join("Library/Containers/com.kakao.KakaoTalkMac/Data/Library/Preferences");
+    fs::create_dir_all(&prefs).unwrap();
+    // Container directory that `check_access` also probes.
+    fs::create_dir_all(home.join(
+        "Library/Containers/com.kakao.KakaoTalkMac/Data/Library/Application Support/com.kakao.KakaoTalkMac",
+    ))
+    .unwrap();
+
+    let mut dict = plist::Dictionary::new();
+    // 26.7 replaced the numeric userId suffix with per-window opaque hashes,
+    // so the exact-suffix strategy cannot recover anything here.
+    dict.insert(
+        "NSWindow Frame FSChatWindowFrame_a7f3c9d1e5b24608".into(),
+        plist::Value::String("649 377 510 400 0 0 1512 982".into()),
+    );
+    dict.insert(
+        "NSWindow Frame FSChatWindowFrame_3b8e2f6a9c0d1475".into(),
+        plist::Value::String("649 377 510 400 0 0 1512 982".into()),
+    );
+    if let Some(id) = direct_user_id {
+        dict.insert("KAKAO_USER_ID".into(), plist::Value::Integer(id.into()));
+    }
+    if let Some(id) = marker_id {
+        dict.insert(
+            format!("DESIGNATEDFRIENDSREVISION:{}", sha512_hex(&id.to_string())),
+            plist::Value::Integer(marker_value.into()),
+        );
+    }
+    let path = prefs.join("com.kakao.KakaoTalkMac.9c31e0ab2d47f658.plist");
+    plist::Value::Dictionary(dict)
+        .to_file_binary(&path)
+        .unwrap();
+}
+
+/// Write the credentials file that `login --save` produces.
+fn write_saved_credentials(home: &Path, user_id: i64) {
+    let dir = home.join(".config").join("openkakao");
+    fs::create_dir_all(&dir).unwrap();
+    let creds = serde_json::json!({
+        "oauth_token": "local-recovery-fixture-token",
+        "user_id": user_id,
+        "device_uuid": "LOCAL-FIXTURE-UUID",
+        "device_name": "openkakao-cli",
+        "app_version": "7.8.2",
+        "user_agent": "KT/7.8.2 Mac/26.7.0 ko",
+        "a_header": "mac/7.8.2/ko"
+    });
+    let path = dir.join("credentials.json");
+    fs::write(&path, creds.to_string()).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+    }
+}
+
+/// Run `check_access()` with $HOME pointed at the simulated KakaoTalk home.
+fn check_access_as(home: &Path, label: &str) -> LocalDbStatus {
+    let _guard = HOME_LOCK.lock().unwrap();
+    let previous = std::env::var_os("HOME");
+    std::env::set_var("HOME", home);
+
+    let started = Instant::now();
+    let status = LocalDbReader::check_access().expect("check_access should not error");
+    let elapsed = started.elapsed();
+
+    if let Some(prev) = previous {
+        std::env::set_var("HOME", prev);
+    } else {
+        std::env::remove_var("HOME");
+    }
+
+    eprintln!(
+        "[{label}] took {:.2}s -> {}",
+        elapsed.as_secs_f32(),
+        serde_json::to_string(&status).unwrap()
+    );
+    status
+}
+
+/// The fix under test: a saved user ID whose SHA-512 matches the plist's
+/// non-zero active-account marker is recovered on a 26.7-style plist where no
+/// numeric suffix survives. The ID is large enough that the bounded brute-force
+/// fallback alone cannot reach it inside its 15s budget, so a pass here means
+/// the saved-ID path itself answered.
+#[test]
+fn kt267_saved_user_id_matching_active_marker_is_recovered() {
+    let home = tempfile::tempdir().unwrap();
+    write_kt267_plist(home.path(), Some(199_453_377), 1, None);
+    write_saved_credentials(home.path(), 199_453_377);
+
+    let status = check_access_as(home.path(), "26.7 plist + matching saved ID");
+
+    assert!(
+        status.user_id_available,
+        "saved ID whose SHA-512 matches the active marker must be recovered: {status:?}"
+    );
+}
+
+/// Stale credentials: a different account is active, so the saved ID must be
+/// rejected rather than blindly reused. The active marker's pre-image sits far
+/// beyond the brute-force budget, so recovery must fail outright.
+#[test]
+fn kt267_stale_saved_user_id_is_rejected() {
+    let home = tempfile::tempdir().unwrap();
+    write_kt267_plist(home.path(), Some(8_888_888_888), 1, None);
+    write_saved_credentials(home.path(), 111_111_111);
+
+    let status = check_access_as(home.path(), "26.7 plist + stale saved ID");
+
+    assert!(
+        !status.user_id_available,
+        "saved ID for a non-active account must be rejected: {status:?}"
+    );
+}
+
+/// Inactive credentials: the marker's revision counter is zero, so even a
+/// hash-matching saved ID must not be trusted.
+#[test]
+fn kt267_inactive_marker_rejects_hash_matching_saved_user_id() {
+    let home = tempfile::tempdir().unwrap();
+    write_kt267_plist(home.path(), Some(199_453_377), 0, None);
+    write_saved_credentials(home.path(), 199_453_377);
+
+    let status = check_access_as(home.path(), "26.7 plist + zero-value marker");
+
+    assert!(
+        !status.user_id_available,
+        "saved ID matching a zero-value (inactive) marker must be rejected: {status:?}"
+    );
+}
+
+/// Fallback preserved: with no saved credentials at all, the bounded SHA-512
+/// brute force still recovers a small user ID from the revision marker.
+#[test]
+fn kt267_brute_force_fallback_survives_without_saved_credentials() {
+    let home = tempfile::tempdir().unwrap();
+    write_kt267_plist(home.path(), Some(12_345), 1, None);
+
+    let status = check_access_as(home.path(), "26.7 plist + no saved credentials");
+
+    assert!(
+        status.user_id_available,
+        "bounded brute-force fallback must keep working without credentials: {status:?}"
+    );
+}
+
+/// Fallback preserved: a legacy direct `KAKAO_USER_ID` key still wins without
+/// any saved credentials or revision marker.
+#[test]
+fn direct_user_id_key_still_wins_without_saved_credentials() {
+    let home = tempfile::tempdir().unwrap();
+    write_kt267_plist(home.path(), None, 0, Some(199_453_377));
+
+    let status = check_access_as(home.path(), "plist with direct KAKAO_USER_ID key");
+
+    assert!(
+        status.user_id_available,
+        "direct-key lookup must keep working: {status:?}"
+    );
+}

--- a/website/content/docs/cli/local-db.mdx
+++ b/website/content/docs/cli/local-db.mdx
@@ -124,10 +124,10 @@ Run `doctor` to check if the local database is accessible:
 openkakao-cli doctor --json
 ```
 
-`doctor` reports the platform UUID, the recovered Kakao user ID, and the resolved database path. To recover the user ID it inspects the KakaoTalk preferences plist using several strategies in order, from cheapest to most expensive — the last is a bounded SHA-512 pre-image search that stops after a short time budget, so `doctor` never hangs even when the user ID cannot be recovered on a given KakaoTalk build.
+`doctor` reports the platform UUID, the recovered Kakao user ID, and the resolved database path. To recover the user ID it tries several strategies in order, from cheapest to most expensive: plist key lookups, then a locally saved user ID (from `login --save`) — trusted only when its SHA-512 exactly matches the plist's non-zero active-account marker, so stale or inactive credentials are rejected — and finally a bounded SHA-512 pre-image search that stops after a short time budget, so `doctor` never hangs even when the user ID cannot be recovered on a given KakaoTalk build.
 
 <Callout title="KakaoTalk 26.x">
-  Newer KakaoTalk macOS builds (26.x) stopped writing some of the plist keys earlier versions used. v1.2.3 adds compatible discovery paths for these builds. If `doctor` still cannot resolve the user ID or database path, set `OPENKAKAO_CLI_DEBUG=1` and re-run to see which strategy was attempted.
+  Newer KakaoTalk macOS builds (26.x) stopped writing some of the plist keys earlier versions used. v1.2.3 adds compatible discovery paths for these builds. KakaoTalk 26.7.0 additionally replaced the numeric `FSChatWindowFrame_` suffixes with opaque hashes, so on that build the user ID comes from the saved-credentials strategy above or the bounded SHA-512 search rather than the plist's numeric keys. If `doctor` still cannot resolve the user ID or database path, set `OPENKAKAO_CLI_DEBUG=1` and re-run to see which strategy was attempted.
 </Callout>
 
 The output includes a `Local DB (SQLCipher)` check that verifies UUID extraction, user ID, file existence, and decryption.


### PR DESCRIPTION
## Summary

- recover KakaoTalk 26.7 user IDs from saved credentials before the bounded SHA-512 brute-force fallback
- cryptographically verify the saved numeric ID against the current plist's non-zero active-account marker
- preserve direct preference extraction and brute-force behavior for installations without a matching saved ID
- expose the existing credentials module to the library target so the shared local DB implementation uses one permission-checked loader

## Validation

- reproduced the pre-fix failure with a KakaoTalk 26.7-style plist and a larger saved user ID
- macOS: full `cargo test`
- macOS: `cargo fmt --check`
- macOS: `cargo clippy --all-targets -- -D warnings`
- live M1 Air: patched `doctor` resolves the user ID immediately and reaches the separately documented SQLCipher decryption warning
- no KakaoTalk message was sent

## Scope

This does not claim to fix the independent SQLCipher key-derivation incompatibility on current KakaoTalk builds.
