### PR TITLE
fix(release): preserve GitHub contributor credits

### DIFF
--- a/.github/workflows/openkakao-cli-release.yml
+++ b/.github/workflows/openkakao-cli-release.yml
@@ -116,7 +116,6 @@ jobs:
           merge-multiple: true
 
       - name: Extract changelog section
-        id: changelog
         env:
           TAG: ${{ github.ref_name }}
         run: |
@@ -127,18 +126,16 @@ jobs:
             /^## \[/ { if (f) exit }
             f
           ' CHANGELOG.md > release-notes.md
-          if [ -s release-notes.md ]; then
-            echo "generate=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "No changelog section for ${VERSION}; falling back to generated notes."
-            echo "generate=true" >> "$GITHUB_OUTPUT"
+          if [ ! -s release-notes.md ]; then
+            echo "No changelog section for ${VERSION}; publishing generated notes only."
           fi
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           body_path: release-notes.md
-          generate_release_notes: ${{ steps.changelog.outputs.generate }}
+          # Keep curated notes while letting GitHub add PR authors and first-time contributors.
+          generate_release_notes: true
           files: |
             dist/openkakao-cli-aarch64-apple-darwin.tar.gz
             dist/openkakao-cli-aarch64-apple-darwin.tar.gz.sha256

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- GitHub releases now keep the curated changelog section and append GitHub-generated PR attribution and first-time-contributor notes, so contributors receive the platform's standard release credit.
+
 ## [1.8.1] - 2026-09-03
 
 ### Added


### PR DESCRIPTION
## Summary

- always enable GitHub-generated release notes alongside the curated changelog body
- let GitHub add PR author attribution and the standard New Contributors section
- keep changelog-only fallback behavior for releases without a curated section

## Root cause

The release workflow set `generate_release_notes=false` whenever a changelog section existed. That bypassed GitHub’s standard contributor attribution even though #51 and its squash commit were correctly authored by @e-jung.

## Validation

- GitHub `generate-notes` preview for v1.8.1 identifies @e-jung as a first-time contributor through #51
- softprops/action-gh-release documents that a supplied body is prepended when `generate_release_notes` is enabled
- workflow YAML parses successfully
- `git diff --check`