### PR TITLE
ci: enforce reliable required checks

### DIFF
--- a/.github/workflows/openkakao-cli-ci.yml
+++ b/.github/workflows/openkakao-cli-ci.yml
@@ -1,26 +1,10 @@
 name: openkakao-cli CI
 
 on:
+  # Required checks must be created for every PR. Path filters can leave a
+  # protected branch waiting forever when a PR only changes docs or workflows.
   push:
-    paths:
-      - "src/**"
-      - "tests/**"
-      - "native/**"
-      - "build.rs"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "rust-toolchain.toml"
-      - ".github/workflows/openkakao-cli-ci.yml"
   pull_request:
-    paths:
-      - "src/**"
-      - "tests/**"
-      - "native/**"
-      - "build.rs"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "rust-toolchain.toml"
-      - ".github/workflows/openkakao-cli-ci.yml"
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -31,6 +15,14 @@ env:
   MANIFEST: Cargo.toml
 
 jobs:
+  workflow-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint GitHub Actions workflows
+        uses: docker://rhysd/actionlint:1.7.12
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -105,3 +97,19 @@ jobs:
 
       - name: Smoke test
         run: ./target/release/openkakao-cli --version
+
+  required:
+    name: required
+    if: ${{ always() }}
+    needs: [workflow-lint, test, lint, build-macos]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs passed
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          if ! jq -e 'all(.[]; .result == "success")' <<<"$NEEDS_JSON"; then
+            echo "One or more required CI jobs did not pass."
+            jq -r 'to_entries[] | "\(.key): \(.value.result)"' <<<"$NEEDS_JSON"
+            exit 1
+          fi

--- a/.github/workflows/openkakao-cli-ci.yml
+++ b/.github/workflows/openkakao-cli-ci.yml
@@ -4,6 +4,8 @@ on:
   # Required checks must be created for every PR. Path filters can leave a
   # protected branch waiting forever when a PR only changes docs or workflows.
   push:
+    branches: [main]
+    tags: ["v*"]
   pull_request:
 
 concurrency:
@@ -44,7 +46,7 @@ jobs:
           restore-keys: cargo-test-${{ runner.os }}-
 
       - name: Cargo test
-        run: cargo test --manifest-path $MANIFEST
+        run: cargo test --manifest-path "$MANIFEST"
 
   lint:
     runs-on: ubuntu-latest
@@ -67,10 +69,10 @@ jobs:
           restore-keys: cargo-lint-${{ runner.os }}-
 
       - name: Cargo fmt
-        run: cargo fmt --manifest-path $MANIFEST --check
+        run: cargo fmt --manifest-path "$MANIFEST" --check
 
       - name: Cargo clippy
-        run: cargo clippy --manifest-path $MANIFEST -- -D warnings
+        run: cargo clippy --manifest-path "$MANIFEST" -- -D warnings
 
   build-macos:
     runs-on: macos-14
@@ -93,7 +95,7 @@ jobs:
           restore-keys: cargo-macos-${{ runner.os }}-
 
       - name: Build release
-        run: cargo build --release --manifest-path $MANIFEST
+        run: cargo build --release --manifest-path "$MANIFEST"
 
       - name: Smoke test
         run: ./target/release/openkakao-cli --version

--- a/.github/workflows/openkakao-cli-release.yml
+++ b/.github/workflows/openkakao-cli-release.yml
@@ -175,9 +175,11 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           ARM_SHA=$(awk '{print $1}' dist/openkakao-cli-aarch64-apple-darwin.tar.gz.sha256)
           X86_SHA=$(awk '{print $1}' dist/openkakao-cli-x86_64-apple-darwin.tar.gz.sha256)
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "arm_sha=$ARM_SHA" >> "$GITHUB_OUTPUT"
-          echo "x86_sha=$X86_SHA" >> "$GITHUB_OUTPUT"
+          {
+            echo "version=$VERSION"
+            echo "arm_sha=$ARM_SHA"
+            echo "x86_sha=$X86_SHA"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Checkout Homebrew tap
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- run CI for every push and pull request so required checks are never silently skipped
- lint every GitHub Actions workflow with actionlint v1.7.12
- add one stable `required` gate for branch protection

## Validation
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- `cargo fmt --manifest-path Cargo.toml --check`
- `cargo clippy --manifest-path Cargo.toml -- -D warnings`
- `cargo test --manifest-path Cargo.toml` (all passed)
- `cargo build --release --manifest-path Cargo.toml`