### PR TITLE
ci: move official actions to Node 24

### DIFF
--- a/.github/workflows/openkakao-cli-ci.yml
+++ b/.github/workflows/openkakao-cli-ci.yml
@@ -20,7 +20,7 @@ jobs:
   workflow-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Lint GitHub Actions workflows
         uses: docker://rhysd/actionlint:1.7.12
@@ -28,7 +28,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -36,7 +36,7 @@ jobs:
           rustflags: ""
 
       - name: Cache cargo registry and build
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -51,7 +51,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -59,7 +59,7 @@ jobs:
           rustflags: ""
 
       - name: Cache cargo registry and build
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -77,7 +77,7 @@ jobs:
   build-macos:
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -85,7 +85,7 @@ jobs:
           rustflags: ""
 
       - name: Cache cargo registry and build
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/openkakao-cli-release.yml
+++ b/.github/workflows/openkakao-cli-release.yml
@@ -17,7 +17,7 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -38,7 +38,7 @@ jobs:
     env:
       TARGET: aarch64-apple-darwin
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -61,7 +61,7 @@ jobs:
           shasum -a 256 "$ASSET" > "$ASSET.sha256"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: openkakao-cli-${{ env.TARGET }}
           path: |
@@ -73,7 +73,7 @@ jobs:
     env:
       TARGET: x86_64-apple-darwin
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -96,7 +96,7 @@ jobs:
           shasum -a 256 "$ASSET" > "$ASSET.sha256"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: openkakao-cli-${{ env.TARGET }}
           path: |
@@ -107,10 +107,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [verify, build-aarch64, build-x86_64]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true
@@ -164,7 +164,7 @@ jobs:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true
@@ -182,7 +182,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Checkout Homebrew tap
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: JungHoonGhae/homebrew-openkakao
           token: ${{ steps.doppler.outputs.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
## Summary
- update `actions/checkout` from v4 to v7
- update `actions/cache` from v4 to v6
- update artifact upload/download actions to the current Node 24 majors
- remove GitHub runner Node 20 deprecation warnings from CI and release workflows

## Validation
- verified each selected major declares `runs.using: node24`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- `git diff --check`